### PR TITLE
Proposal: Make the Device flow independent of Google

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,33 +56,14 @@
 //! match res {
 //!     Ok(t) => {
 //!     // now you can use t.access_token to authenticate API calls within your
-//!     // given scopes. It will not be valid forever, which is when you have to
-//!     // refresh it using the `RefreshFlow`
+//!     // given scopes. It will not be valid forever, but Authenticator will automatically
+//!     // refresh the token for you.
 //!     },
 //!     Err(err) => println!("Failed to acquire token: {}", err),
 //! }
 //! # }
 //! ```
 //!
-//! # Refresh Flow Usage
-//! As the `Token` you retrieved previously will only be valid for a certain time, you will have
-//! to use the information from the `Token.refresh_token` field to get a new `access_token`.
-//!
-//! ```test_harness,no_run
-//! extern crate hyper;
-//! extern crate yup_oauth2 as oauth2;
-//! use oauth2::{RefreshFlow, FlowType, RefreshResult};
-//!
-//! # #[test] fn refresh() {
-//! let mut f = RefreshFlow::new(hyper::Client::new());
-//! let new_token = match *f.refresh_token(FlowType::Device,
-//!                                        "my_client_id", "my_secret",
-//!                                        "my_refresh_token") {
-//!                        RefreshResult::Success(ref t) => t,
-//!                        _ => panic!("bad luck ;)")
-//!                };
-//! # }
-//! ```
 #![cfg_attr(feature = "nightly", feature(custom_derive, custom_attribute, plugin))]
 #![cfg_attr(feature = "nightly", plugin(serde_macros))]
 

--- a/src/lib.rs.in
+++ b/src/lib.rs.in
@@ -22,7 +22,7 @@ mod service_account;
 mod storage;
 mod types;
 
-pub use device::DeviceFlow;
+pub use device::{GOOGLE_DEVICE_CODE_URL, DeviceFlow};
 pub use refresh::{RefreshFlow, RefreshResult};
 pub use types::{Token, FlowType, ApplicationSecret, ConsoleApplicationSecret, Scheme, TokenType};
 pub use installed::{InstalledFlow, InstalledFlowReturnMethod};

--- a/src/types.rs
+++ b/src/types.rs
@@ -227,11 +227,13 @@ impl Token {
 }
 
 /// All known authentication types, for suitable constants
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum FlowType {
     /// [device authentication](https://developers.google.com/youtube/v3/guides/authentication#devices). Only works
     /// for certain scopes.
-    Device,
+    /// Contains the device token URL; for google, that is
+    /// https://accounts.google.com/o/oauth2/device/code (exported as `GOOGLE_DEVICE_CODE_URL`)
+    Device(String),
     /// [installed app flow](https://developers.google.com/identity/protocols/OAuth2InstalledApp). Required
     /// for Drive, Calendar, Gmail...; Requires user to paste a code from the browser.
     InstalledInteractive,
@@ -240,17 +242,6 @@ pub enum FlowType {
     /// Windows Firewall, but is more comfortable otherwise. The integer describes which port to
     /// bind to (default: 8080)
     InstalledRedirect(u32),
-}
-
-impl AsRef<str> for FlowType {
-    /// Converts itself into a URL string
-    fn as_ref(&self) -> &'static str {
-        match *self {
-            FlowType::Device => "https://accounts.google.com/o/oauth2/device/code",
-            FlowType::InstalledInteractive => "https://accounts.google.com/o/oauth2/v2/auth",
-            FlowType::InstalledRedirect(_) => "https://accounts.google.com/o/oauth2/v2/auth",
-        }
-    }
 }
 
 /// Represents either 'installed' or 'web' applications in a json secrets file.


### PR DESCRIPTION
This is a breaking change; it's supposed to fix #1. Also, it's a proposal -- not sure if the benefits outweigh the cost of this.

The example/auth.rs binary is not broken by this, as it doesn't use the API that changed. The tests have been updated accordingly and pass.

Short summary of how it works: `FlowType::Device` now has an inner `String` which is the URL of the Device code endpoint (that URL is unfortunately not in the client secret). The other URLs (token URL, for example) are taken from the `ApplicationSecret`.

Google's default Device code endpoint is exported as `GOOGLE_DEVICE_CODE_URL` for easier use.
