### PR TITLE
docs(links): link from byron/ to dermesser/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@
 name = "yup-oauth2"
 version = "1.0.0"
 authors = ["Sebastian Thiel <byronimo@gmail.com>", "Lewin Bormann <lbo@spheniscida.de>"]
-repository = "https://github.com/Byron/yup-oauth2"
+repository = "https://github.com/dermesser/yup-oauth2"
 description = "An oauth2 implementation, providing the 'device' and 'installed' authorization flow"
-documentation = "http://byron.github.io/yup-oauth2"
+documentation = "http://dermesser.github.io/yup-oauth2"
 keywords = ["google", "oauth", "v2"]
 license = "MIT OR Apache-2.0"
 build = "src/build.rs"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build
 Status](https://travis-ci.org/dermesser/yup-oauth2.svg)](https://travis-ci.org/dermesser/yup-oauth2)
 [![Coverage
-Status](https://coveralls.io/repos/github/Byron/yup-oauth2/badge.svg?branch=master)](https://coveralls.io/github/Byron/yup-oauth2?branch=master)
+Status](https://coveralls.io/repos/github/dermesser/yup-oauth2/badge.svg?branch=master)](https://coveralls.io/github/dermesser/yup-oauth2?branch=master)
 [![crates.io](https://img.shields.io/crates/v/yup-oauth2.svg)](https://crates.io/crates/yup-oauth2)
 
 **yup-oauth2** is a utility library which implements several OAuth 2.0 flows. It's mainly used by


### PR DESCRIPTION
The only link not working just yet is coveralls, which
apparently needs a login by the owner and minor configuration
to work (e.g. webhooks).

Also please note that the Cargo.toml has changed to fix the
documentation link. It would need a re-publish to fix it appears.
