### PR TITLE
Use docs.rs for documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,11 @@ before_script:
   - pip install 'travis-cargo<0.2' --user  && export PATH=$HOME/Library/Python/2.7/bin:$HOME/.local/bin:$PATH
 script:
   - travis-cargo test -- --features $FEATURE --no-default-features
-  - travis-cargo doc -- --features $FEATURE --no-default-features
 after_success:
-  - "[[ $TRAVIS_OS_NAME = linux ]] && travis-cargo --only stable doc-upload"
   - "[[ $TRAVIS_OS_NAME = linux ]] && travis-cargo --only stable coveralls"
 env:
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
-    - secure: "J3jotdDitbd+Lzx1hsafqrCXYTOC/BJUuVzcrXGr94+hetbd1S79aUEW3j1sBfmIhgHpgss2FkzqvvxpYjurMkqBtgWEb/eN942+gqGNuWZPi+wP/DOYWUrd1iaCT6cihHB6lfd54HB3DUOuwtVUz3m9twAYZ8leeHeSUD12O5k="
   matrix:
     - FEATURE=with-serde-codegen
     - FEATURE=nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 
 name = "yup-oauth2"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Sebastian Thiel <byronimo@gmail.com>", "Lewin Bormann <lbo@spheniscida.de>"]
 repository = "https://github.com/dermesser/yup-oauth2"
-description = "An oauth2 implementation, providing the 'device' and 'installed' authorization flow"
-documentation = "http://dermesser.github.io/yup-oauth2"
+description = "An oauth2 implementation, providing the 'device', 'service account' and 'installed' authorization flows"
+documentation = "https://docs.rs/yup-oauth2/"
 keywords = ["google", "oauth", "v2"]
 license = "MIT OR Apache-2.0"
 build = "src/build.rs"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ work by you, as defined in the Apache-2.0 license, shall be dual licensed as abo
 additional terms or conditions.
 
 
-[API-docs]: http://dermesser.github.io/yup-oauth2
+[API-docs]: https://docs.rs/yup-oauth2/
 [examples]: https://github.com/dermesser/yup-oauth2/tree/master/examples
 [auth-usage]: https://raw.githubusercontent.com/dermesser/yup-oauth2/master/examples/auth.rs-usage.gif
 


### PR DESCRIPTION
@Byron Let me know if I forgot something; I grepped for locations pointing to the old documentation, but I think I got everything (but it's your setup, so you know it better :)

I'll add a redirect page to `gh-pages` afterwards, so nobody is confused by stale documentation.