### PR TITLE
Allow nightly fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   allow_failures:
     - os: osx
     - rust: nightly
+      env: FEATURE=nightly
 before_script:
   - pip install 'travis-cargo<0.2' --user  && export PATH=$HOME/Library/Python/2.7/bin:$HOME/.local/bin:$PATH
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
       env: FEATURE=nightly
   allow_failures:
     - os: osx
+    - rust: nightly
 before_script:
   - pip install 'travis-cargo<0.2' --user  && export PATH=$HOME/Library/Python/2.7/bin:$HOME/.local/bin:$PATH
 script:


### PR DESCRIPTION
Allow the combination (rustc nightly, FEATURES=nightly) to fail. Some crates that this build depends on are flaky, and frequently cause build fails.