### PR TITLE
No openssl feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ script:
   - travis-cargo test
   - travis-cargo build -- --manifest-path examples/drive_example/Cargo.toml
   - travis-cargo build -- --manifest-path examples/service_account/Cargo.toml
+  - travis-cargo test -- --no-default-features --features no-openssl
 after_success:
   - "[[ $TRAVIS_OS_NAME = linux ]] && travis-cargo --only stable coveralls"
 env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,16 @@ hyper = "0.10.2"
 hyper-native-tls = "0.3"
 itertools = "0.7"
 log = "0.3"
-openssl = "0.10"
+openssl = {version = "0.10", optional = true}
+rustls = {version = "0.14", optional = true}
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 url = "1"
+
+[features]
+default = ["openssl"]
+no-openssl = ["rustls"]
 
 [dev-dependencies]
 getopts = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "An oauth2 implementation, providing the 'device', 'service accoun
 documentation = "https://docs.rs/yup-oauth2/"
 keywords = ["google", "oauth", "v2"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 
 [dependencies]
 base64 = "0.9"

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,11 +1,5 @@
-extern crate yup_oauth2 as oauth2;
-extern crate yup_hyper_mock as mock;
-extern crate hyper;
-extern crate chrono;
-extern crate getopts;
-extern crate open;
-
-use oauth2::GetToken;
+use yup_oauth2::{self as oauth2, GetToken};
+use yup_hyper_mock as mock;
 use chrono::{Local};
 use getopts::{HasArg,Options,Occur,Fail};
 use std::env;

--- a/examples/drive_example/Cargo.toml
+++ b/examples/drive_example/Cargo.toml
@@ -2,6 +2,7 @@
 name = "drive_example"
 version = "0.1.0"
 authors = ["Lewin Bormann <lbo@spheniscida.de>"]
+edition = "2018"
 
 [dependencies]
 yup-oauth2 = "^ 1.0"

--- a/examples/service_account/Cargo.toml
+++ b/examples/service_account/Cargo.toml
@@ -2,6 +2,7 @@
 name = "service_account"
 version = "0.1.0"
 authors = ["Lewin Bormann <lewin@lewin-bormann.info>"]
+edition = "2018"
 
 [dependencies]
 base64 = "0.2"

--- a/examples/service_account/src/main.rs
+++ b/examples/service_account/src/main.rs
@@ -25,8 +25,6 @@
 //! Copyright (c) 2016 Google, Inc. (Lewin Bormann <lbo@spheniscida.de>)
 //!
 extern crate base64;
-extern crate yup_oauth2 as oauth;
-extern crate google_pubsub1 as pubsub;
 extern crate hyper;
 extern crate hyper_native_tls;
 
@@ -34,9 +32,10 @@ use std::env;
 use std::time;
 use std::thread;
 
+use yup_oauth2 as oauth;
 use hyper::net::HttpsConnector;
 use hyper_native_tls::NativeTlsClient;
-use pubsub::{Topic, Subscription};
+use google_pubsub1::{self as pubsub, Topic, Subscription};
 
 // The prefixes are important!
 const SUBSCRIPTION_NAME: &'static str = "projects/sanguine-rhythm-105020/subscriptions/rust_authd_sub_1";
@@ -52,7 +51,7 @@ fn check_or_create_topic(methods: &PubsubMethods) -> Topic {
 
     if result.is_err() {
         println!("Assuming topic doesn't exist; creating topic");
-        let topic = pubsub::Topic { name: Some(TOPIC_NAME.to_string()) };
+        let topic = pubsub::Topic { name: Some(TOPIC_NAME.to_string()), labels: None };
         let result = methods.topics_create(topic, TOPIC_NAME).doit().unwrap();
         result.1
     } else {
@@ -73,6 +72,7 @@ fn check_or_create_subscription(methods: &PubsubMethods) -> Subscription {
             message_retention_duration: None,
             retain_acked_messages: None,
             name: Some(SUBSCRIPTION_NAME.to_string()),
+            labels: None,
         };
         let (_resp, sub) = methods.subscriptions_create(sub, SUBSCRIPTION_NAME).doit().unwrap();
 
@@ -170,7 +170,7 @@ fn main() {
     let client = hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
     let mut access = oauth::ServiceAccountAccess::new(client_secret, client);
 
-    use oauth::GetToken;
+    use yup_oauth2::GetToken;
     println!("{:?}",
              access.token(&vec!["https://www.googleapis.com/auth/pubsub"]).unwrap());
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -6,14 +6,14 @@ use std::error::Error;
 use std::hash::{Hash, Hasher};
 use std::iter::IntoIterator;
 use std::thread::sleep;
-
-use authenticator_delegate::{AuthenticatorDelegate, PollError, PollInformation};
-use device::{GOOGLE_DEVICE_CODE_URL, DeviceFlow};
-use installed::{InstalledFlow, InstalledFlowReturnMethod};
-use refresh::{RefreshResult, RefreshFlow};
 use std::time::Duration;
-use storage::TokenStorage;
-use types::{RequestError, StringError, Token, FlowType, ApplicationSecret};
+
+use crate::authenticator_delegate::{AuthenticatorDelegate, PollError, PollInformation};
+use crate::device::{GOOGLE_DEVICE_CODE_URL, DeviceFlow};
+use crate::installed::{InstalledFlow, InstalledFlowReturnMethod};
+use crate::refresh::{RefreshResult, RefreshFlow};
+use crate::storage::TokenStorage;
+use crate::types::{RequestError, StringError, Token, FlowType, ApplicationSecret};
 
 use hyper;
 
@@ -326,8 +326,8 @@ mod tests {
     use super::super::device::tests::MockGoogleAuth;
     use super::super::types::tests::SECRET;
     use super::super::types::ConsoleApplicationSecret;
-    use authenticator_delegate::DefaultAuthenticatorDelegate;
-    use storage::MemoryStorage;
+    use crate::authenticator_delegate::DefaultAuthenticatorDelegate;
+    use crate::storage::MemoryStorage;
     use std::default::Default;
     use hyper;
 

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -4,8 +4,8 @@ use std::fmt;
 use std::io;
 use std::error::Error;
 
-use authenticator::Retry;
-use types::RequestError;
+use crate::authenticator::Retry;
+use crate::types::RequestError;
 
 use chrono::{DateTime, Local, Utc};
 use std::time::Duration;
@@ -63,7 +63,7 @@ pub trait AuthenticatorDelegate {
     /// Called whenever there is an HttpError, usually if there are network problems.
     ///
     /// Return retry information.
-    fn connection_error(&mut self, &hyper::Error) -> Retry {
+    fn connection_error(&mut self, _: &hyper::Error) -> Retry {
         Retry::Abort
     }
 
@@ -78,12 +78,12 @@ pub trait AuthenticatorDelegate {
     }
 
     /// The server denied the attempt to obtain a request code
-    fn request_failure(&mut self, RequestError) {}
+    fn request_failure(&mut self, _: RequestError) {}
 
     /// Called if the request code is expired. You will have to start over in this case.
     /// This will be the last call the delegate receives.
     /// Given `DateTime` is the expiration date
-    fn expired(&mut self, &DateTime<Utc>) {}
+    fn expired(&mut self, _: &DateTime<Utc>) {}
 
     /// Called if the user denied access. You would have to start over.
     /// This will be the last call the delegate receives.
@@ -108,7 +108,7 @@ pub trait AuthenticatorDelegate {
     /// # Notes
     /// * Only used in `DeviceFlow`. Return value will only be used if it
     /// is larger than the interval desired by the server.
-    fn pending(&mut self, &PollInformation) -> Retry {
+    fn pending(&mut self, _: &PollInformation) -> Retry {
         Retry::After(Duration::from_secs(5))
     }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -12,8 +12,8 @@ use std::borrow::BorrowMut;
 use std::io::Read;
 use std::i64;
 
-use types::{ApplicationSecret, Token, FlowType, Flow, RequestError, JsonError};
-use authenticator_delegate::{PollError, PollInformation};
+use crate::types::{ApplicationSecret, Token, FlowType, Flow, RequestError, JsonError};
+use crate::authenticator_delegate::{PollError, PollInformation};
 
 pub const GOOGLE_DEVICE_CODE_URL: &'static str = "https://accounts.google.com/o/oauth2/device/code";
 
@@ -294,7 +294,7 @@ pub mod tests {
 
     #[test]
     fn working_flow() {
-        use helper::parse_application_secret;
+        use crate::helper::parse_application_secret;
 
         let appsecret = parse_application_secret(&TEST_APP_SECRET.to_string()).unwrap();
         let mut flow = DeviceFlow::new(

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -13,16 +13,16 @@ use std::io::{self, Read};
 use std::fs;
 use std::path::Path;
 
-use service_account::ServiceAccountKey;
-use types::{ConsoleApplicationSecret, ApplicationSecret};
+use crate::service_account::ServiceAccountKey;
+use crate::types::{ConsoleApplicationSecret, ApplicationSecret};
 
 /// Read an application secret from a file.
 pub fn read_application_secret(path: &Path) -> io::Result<ApplicationSecret> {
     use std::io::Read;
 
     let mut secret = String::new();
-    let mut file = try!(fs::OpenOptions::new().read(true).open(path));
-    try!(file.read_to_string(&mut secret));
+    let mut file = fs::OpenOptions::new().read(true).open(path)?;
+    file.read_to_string(&mut secret)?;
 
     parse_application_secret(&secret)
 }
@@ -52,8 +52,8 @@ pub fn parse_application_secret(secret: &String) -> io::Result<ApplicationSecret
 /// Cloud Console or the respective console of your service provider.
 pub fn service_account_key_from_file(path: &String) -> io::Result<ServiceAccountKey> {
     let mut key = String::new();
-    let mut file = try!(fs::OpenOptions::new().read(true).open(path));
-    try!(file.read_to_string(&mut key));
+    let mut file = fs::OpenOptions::new().read(true).open(path)?;
+    file.read_to_string(&mut key)?;
 
     match serde_json::from_str(&key) {
         Err(e) => Err(io::Error::new(io::ErrorKind::InvalidData, format!("{}", e))),

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -19,8 +19,8 @@ use serde_json::error;
 use url::form_urlencoded;
 use url::percent_encoding::{percent_encode, QUERY_ENCODE_SET};
 
-use types::{ApplicationSecret, Token};
-use authenticator_delegate::AuthenticatorDelegate;
+use crate::types::{ApplicationSecret, Token};
+use crate::authenticator_delegate::AuthenticatorDelegate;
 
 const OOB_REDIRECT_URI: &'static str = "urn:ietf:wg:oauth:2.0:oob";
 
@@ -134,8 +134,8 @@ impl<C> InstalledFlow<C>
         where T: AsRef<str> + 'a,
               S: Iterator<Item = &'a T>
     {
-        let authcode = try!(self.get_authorization_code(auth_delegate, &appsecret, scopes));
-        let tokens = try!(self.request_token(&appsecret, &authcode));
+        let authcode = self.get_authorization_code(auth_delegate, &appsecret, scopes)?;
+        let tokens = self.request_token(&appsecret, &authcode)?;
 
         // Successful response
         if tokens.access_token.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,7 @@
 //! #[macro_use]
 //! extern crate serde_derive;
 //! 
-//! extern crate hyper;
-//! extern crate hyper_native_tls;
-//! extern crate yup_oauth2 as oauth2;
-//! extern crate serde;
-//! extern crate serde_json;
-//!
-//! use oauth2::{Authenticator, DefaultAuthenticatorDelegate, PollInformation, ConsoleApplicationSecret, MemoryStorage, GetToken};
+//! use yup_oauth2::{Authenticator, DefaultAuthenticatorDelegate, PollInformation, ConsoleApplicationSecret, MemoryStorage, GetToken};
 //! use serde_json as json;
 //! use std::default::Default;
 //! use hyper::{Client, net::HttpsConnector};
@@ -78,7 +72,6 @@ extern crate base64;
 extern crate chrono;
 extern crate hyper;
 extern crate hyper_native_tls;
-extern crate openssl;
 
 #[cfg(test)]
 extern crate log;
@@ -97,14 +90,14 @@ mod service_account;
 mod storage;
 mod types;
 
-pub use device::{GOOGLE_DEVICE_CODE_URL, DeviceFlow};
-pub use refresh::{RefreshFlow, RefreshResult};
-pub use types::{Token, FlowType, ApplicationSecret, ConsoleApplicationSecret, Scheme, TokenType};
-pub use installed::{InstalledFlow, InstalledFlowReturnMethod};
-pub use storage::{TokenStorage, NullStorage, MemoryStorage, DiskTokenStorage};
-pub use authenticator::{Authenticator, Retry, GetToken};
-pub use authenticator_delegate::{AuthenticatorDelegate, DefaultAuthenticatorDelegate, PollError,
+pub use crate::device::{GOOGLE_DEVICE_CODE_URL, DeviceFlow};
+pub use crate::refresh::{RefreshFlow, RefreshResult};
+pub use crate::types::{Token, FlowType, ApplicationSecret, ConsoleApplicationSecret, Scheme, TokenType};
+pub use crate::installed::{InstalledFlow, InstalledFlowReturnMethod};
+pub use crate::storage::{TokenStorage, NullStorage, MemoryStorage, DiskTokenStorage};
+pub use crate::authenticator::{Authenticator, Retry, GetToken};
+pub use crate::authenticator_delegate::{AuthenticatorDelegate, DefaultAuthenticatorDelegate, PollError,
                                  PollInformation};
-pub use helper::*;
-pub use service_account::*;
+pub use crate::helper::*;
+pub use crate::service_account::*;
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,4 +1,4 @@
-use types::{ApplicationSecret, FlowType, JsonError};
+use crate::types::{ApplicationSecret, FlowType, JsonError};
 
 use chrono::Utc;
 use hyper;
@@ -125,8 +125,8 @@ mod tests {
     use super::*;
     use super::super::FlowType;
     use yup_hyper_mock::{MockStream, SequentialConnector};
-        use helper::parse_application_secret;
-        use device::GOOGLE_DEVICE_CODE_URL;
+        use crate::helper::parse_application_secret;
+        use crate::device::GOOGLE_DEVICE_CODE_URL;
 
     struct MockGoogleRefresh(SequentialConnector);
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -14,7 +14,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{Read, Write};
 use std::io;
 
-use types::Token;
+use crate::types::Token;
 
 /// Implements a specialized storage to set and retrieve `Token` instances.
 /// The `scope_hash` represents the signature of the scopes for which the given token
@@ -149,7 +149,7 @@ impl DiskTokenStorage {
     }
 
     fn load_from_file(&mut self) -> Result<(), io::Error> {
-        let mut f = try!(fs::OpenOptions::new().read(true).open(&self.location));
+        let mut f = fs::OpenOptions::new().read(true).open(&self.location)?;
         let mut contents = String::new();
 
         match f.read_to_string(&mut contents) {
@@ -187,11 +187,11 @@ impl DiskTokenStorage {
             Result::Ok(s) => serialized = s,
         }
 
-        let mut f = try!(fs::OpenOptions::new()
+        let mut f = fs::OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
-            .open(&self.location));
+            .open(&self.location)?;
         f.write(serialized.as_ref()).map(|_| ())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,9 +50,9 @@ impl fmt::Display for RequestError {
             RequestError::InvalidClient => "Invalid Client".fmt(f),
             RequestError::InvalidScope(ref scope) => writeln!(f, "Invalid Scope: '{}'", scope),
             RequestError::NegativeServerResponse(ref error, ref desc) => {
-                try!(error.fmt(f));
+                error.fmt(f)?;
                 if let &Some(ref desc) = desc {
-                    try!(write!(f, ": {}", desc));
+                    write!(f, ": {}", desc)?;
                 }
                 "\n".fmt(f)
             }


### PR DESCRIPTION
From commit message:

> Recently, commits were made to remove support for using rustls/ring
> in lieu of OpenSSL to avoid having to add those as dependencies in
> environments where OpenSSL already exists.
> 
> However, yup-oauth2 is being used in some environments where
> *OpenSSL* doesn't exist. So, retaining the option to build
> it with an openssl-free stack is key.
> 
> Note, the change to hyper-native-tls is fine and actually
> unrelated, because this is often happening on Windows or
> Mac enviornments, where the stack that will link to is
> *not* necessarily OpenSSL either.
> 
> For example, the particular breakage that prompted this
> CR is a build of yup-oauth2 on iOS. In that environment,
> hyper-native-tls uses Apple's Security Framework,
> but OpenSSL libraries are not actually present on all
> devices/simulator environments. So a link against
> a mix of Security Framework and rustls make sense,
> there.
> 
> Also, update to a newer version of rustls/ring while we're at it.