### PR TITLE
imp(flows) don't require present_user_url to return an additional char

### DIFF
--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -137,7 +137,11 @@ pub trait AuthenticatorDelegate {
                      url);
 
             let mut code = String::new();
-            io::stdin().read_line(&mut code).ok().map(|_| code)
+            io::stdin().read_line(&mut code).ok().map(|_| {
+                // Remove newline
+                code.pop();
+                code
+            })
         } else {
             println!("Please direct your browser to {} and follow the instructions displayed \
                       there.",

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -181,9 +181,14 @@ impl<C> InstalledFlow<C>
                         Result::Err(Box::new(io::Error::new(io::ErrorKind::UnexpectedEof,
                                                             "couldn't read code")))
                     }
-                    // Remove newline
                     Some(mut code) => {
-                        code.pop();
+                        // Partial backwards compatibilty in case an implementation adds a new line
+                        // due to previous behaviour.
+                        let ends_with_newline =
+                            code.chars().last().map(|c| c == '\n').unwrap_or(false);
+                        if ends_with_newline {
+                            code.pop();
+                        }
                         Result::Ok(code)
                     }
                 }


### PR DESCRIPTION
For custom AuthenticatorDelegate implementations it may be very weird to
be required to return an additional character after the code from
present_user_url.

One may find himself chasing the bug which is bad UX for the user.

Improve this behavior and therefore introduce a breaking change that
will hopefully not break existing implementations nevertheless.