### PR TITLE
Have the installed flow http server always listen on an ephemeral port.

### DIFF
--- a/examples/test-installed/src/main.rs
+++ b/examples/test-installed/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         client.clone(),
         ad,
         secret,
-        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect(8081),
+        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
     );
     let mut auth = Authenticator::new_disk(
         client,

--- a/examples/test-installed/src/main.rs
+++ b/examples/test-installed/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         client.clone(),
         ad,
         secret,
-        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirectEphemeral,
     );
     let mut auth = Authenticator::new_disk(
         client,

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -97,9 +97,8 @@ pub enum InstalledFlowReturnMethod {
     /// (default)
     Interactive,
     /// Involves spinning up a local HTTP server and Google redirecting the browser to
-    /// the server with a URL containing the code (preferred, but not as reliable). The
-    /// parameter is the port to listen on.
-    HTTPRedirect(u16),
+    /// the server with a URL containing the code (preferred, but not as reliable).
+    HTTPRedirect,
 }
 
 impl<'c, FD: 'static + FlowDelegate + Clone + Send, C: 'c + hyper::client::connect::Connect>
@@ -134,8 +133,8 @@ impl<'c, FD: 'static + FlowDelegate + Clone + Send, C: 'c + hyper::client::conne
     ) -> impl 'a + Future<Item = Token, Error = RequestError> + Send {
         let rduri = self.fd.redirect_uri();
         // Start server on localhost to accept auth code.
-        let server = if let InstalledFlowReturnMethod::HTTPRedirect(port) = self.method {
-            match InstalledFlowServer::new(port) {
+        let server = if let InstalledFlowReturnMethod::HTTPRedirect = self.method {
+            match InstalledFlowServer::new() {
                 Result::Err(e) => Err(RequestError::ClientError(e)),
                 Result::Ok(server) => Ok(Some(server)),
             }
@@ -328,7 +327,7 @@ struct InstalledFlowServer {
 }
 
 impl InstalledFlowServer {
-    fn new(port: u16) -> Result<InstalledFlowServer, hyper::error::Error> {
+    fn new() -> Result<InstalledFlowServer, hyper::error::Error> {
         let (auth_code_tx, auth_code_rx) = oneshot::channel::<String>();
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
@@ -338,8 +337,8 @@ impl InstalledFlowServer {
             .build();
         let service_maker = InstalledFlowServiceMaker::new(auth_code_tx);
 
-        let addr = format!("127.0.0.1:{}", port);
-        let builder = hyper::server::Server::try_bind(&addr.parse().unwrap())?;
+        let addr: std::net::SocketAddr = ([127, 0, 0, 1], 0).into();
+        let builder = hyper::server::Server::try_bind(&addr)?;
         let server = builder.http1_only(true).serve(service_maker);
         let port = server.local_addr().port();
         let server_future = server
@@ -644,7 +643,7 @@ mod tests {
                     client.clone(),
                 ),
                 app_secret,
-                InstalledFlowReturnMethod::HTTPRedirect(8081),
+                InstalledFlowReturnMethod::HTTPRedirect,
             );
             let _m = mock("POST", "/token")
             .match_body(mockito::Matcher::Regex(".*code=authorizationcodefromlocalserver.*client_id=9022167.*".to_string()))
@@ -706,8 +705,8 @@ mod tests {
 
     #[test]
     fn test_server_random_local_port() {
-        let addr1 = InstalledFlowServer::new(0).unwrap();
-        let addr2 = InstalledFlowServer::new(0).unwrap();
+        let addr1 = InstalledFlowServer::new().unwrap();
+        let addr2 = InstalledFlowServer::new().unwrap();
         assert_ne!(addr1.port, addr2.port);
     }
 
@@ -730,7 +729,7 @@ mod tests {
             hyper::Client::builder()
                 .executor(runtime.executor())
                 .build_http();
-        let mut server = InstalledFlowServer::new(0).unwrap();
+        let mut server = InstalledFlowServer::new().unwrap();
 
         let response = client
             .get(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!         client.clone(),
 //!         ad,
 //!         secret,
-//!         yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect(8081),
+//!         yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
 //!     );
 //!     // You could already use InstalledFlow by itself, but usually you want to cache tokens and
 //!     // refresh them, rather than ask the user every time to log in again. Authenticator wraps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@
 //!         client.clone(),
 //!         ad,
 //!         secret,
-//!         yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+//!         yup_oauth2::InstalledFlowReturnMethod::HTTPRedirectEphemeral,
 //!     );
 //!     // You could already use InstalledFlow by itself, but usually you want to cache tokens and
 //!     // refresh them, rather than ask the user every time to log in again. Authenticator wraps


### PR DESCRIPTION
Consider this pull request a question: Are there ever reasons to specify the port the installed flow server should listen on? I initially intended to just document that zero will choose an ephemeral port and that's what most people should use, but after thinking for a while I wasn't able to come up with any situation where specifying a port would be worthwhile so I opted to remove it.