### PR TITLE
Use the builder pattern to create authenticators.

### DIFF
--- a/examples/service_account/src/main.rs
+++ b/examples/service_account/src/main.rs
@@ -178,15 +178,13 @@ fn publish_stuff(methods: &PubsubMethods, message: &str) {
 fn main() {
     let client_secret =
         oauth::service_account_key_from_file(&"pubsub-auth.json".to_string()).unwrap();
-    let client =
-        hyper::Client::with_connector(HttpsConnector::new(NativeTlsClient::new().unwrap()));
-    let mut access = oauth::ServiceAccountAccess::new(client_secret, client);
+    let mut access = oauth::ServiceAccountAccess::new(client_secret).build();
 
     use yup_oauth2::GetToken;
     println!(
         "{:?}",
         access
-            .token(&vec!["https://www.googleapis.com/auth/pubsub"])
+            .token(vec!["https://www.googleapis.com/auth/pubsub"])
             .unwrap()
     );
 

--- a/examples/test-device/src/main.rs
+++ b/examples/test-device/src/main.rs
@@ -1,36 +1,20 @@
 use futures::prelude::*;
-use yup_oauth2::{self, Authenticator, GetToken};
+use yup_oauth2::{self, Authenticator, DeviceFlow, GetToken};
 
-use hyper::client::Client;
-use hyper_rustls::HttpsConnector;
 use std::path;
-use std::time::Duration;
 use tokio;
 
 fn main() {
     let creds = yup_oauth2::read_application_secret(path::Path::new("clientsecret.json"))
         .expect("clientsecret");
-    let https = HttpsConnector::new(1);
-    let client = Client::builder()
-        .keep_alive(false)
-        .build::<_, hyper::Body>(https);
-    let scopes = &["https://www.googleapis.com/auth/youtube.readonly".to_string()];
+    let mut auth = Authenticator::new(DeviceFlow::new(creds))
+        .persist_tokens_to_disk("tokenstorage.json")
+        .build()
+        .expect("authenticator");
 
-    let ad = yup_oauth2::DefaultFlowDelegate;
-    let mut df = yup_oauth2::DeviceFlow::new::<String>(client.clone(), creds, ad, None);
-    df.set_wait_duration(Duration::from_secs(120));
-    let mut auth = Authenticator::new_disk(
-        client,
-        df,
-        yup_oauth2::DefaultAuthenticatorDelegate,
-        "tokenstorage.json",
-    )
-    .expect("authenticator");
-
+    let scopes = vec!["https://www.googleapis.com/auth/youtube.readonly"];
     let mut rt = tokio::runtime::Runtime::new().unwrap();
-    let fut = auth
-        .token(scopes.iter())
-        .and_then(|tok| Ok(println!("{:?}", tok)));
+    let fut = auth.token(scopes).and_then(|tok| Ok(println!("{:?}", tok)));
 
     println!("{:?}", rt.block_on(fut));
 }

--- a/examples/test-installed/src/main.rs
+++ b/examples/test-installed/src/main.rs
@@ -15,23 +15,18 @@ fn main() {
     let ad = yup_oauth2::DefaultFlowDelegate;
     let secret = yup_oauth2::read_application_secret(Path::new("clientsecret.json"))
         .expect("clientsecret.json");
-    let inf = InstalledFlow::new(
-        client.clone(),
-        ad,
+
+    let mut auth = Authenticator::new(InstalledFlow::new(
         secret,
-        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirectEphemeral,
-    );
-    let mut auth = Authenticator::new_disk(
-        client,
-        inf,
-        yup_oauth2::DefaultAuthenticatorDelegate,
-        "tokencache.json",
-    )
+        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect(8081),
+    ))
+    .persist_tokens_to_disk("tokencache.json")
+    .build()
     .unwrap();
     let s = "https://www.googleapis.com/auth/drive.file".to_string();
     let scopes = vec![s];
 
-    let tok = auth.token(scopes.iter());
+    let tok = auth.token(scopes);
     let fut = tok.map_err(|e| println!("error: {:?}", e)).and_then(|t| {
         println!("The token is {:?}", t);
         Ok(())

--- a/examples/test-svc-acct/src/main.rs
+++ b/examples/test-svc-acct/src/main.rs
@@ -3,8 +3,6 @@ use yup_oauth2;
 use futures::prelude::*;
 use yup_oauth2::GetToken;
 
-use hyper::client::Client;
-use hyper_rustls::HttpsConnector;
 use tokio;
 
 use std::path;
@@ -12,21 +10,16 @@ use std::path;
 fn main() {
     let creds =
         yup_oauth2::service_account_key_from_file(path::Path::new("serviceaccount.json")).unwrap();
-    let https = HttpsConnector::new(1);
-    let client = Client::builder()
-        .keep_alive(false)
-        .build::<_, hyper::Body>(https);
-
-    let mut sa = yup_oauth2::ServiceAccountAccess::new(creds, client);
+    let mut sa = yup_oauth2::ServiceAccountAccess::new(creds).build();
 
     let fut = sa
-        .token(["https://www.googleapis.com/auth/pubsub"].iter())
+        .token(vec!["https://www.googleapis.com/auth/pubsub"])
         .and_then(|tok| {
             println!("token is: {:?}", tok);
             Ok(())
         });
     let fut2 = sa
-        .token(["https://www.googleapis.com/auth/pubsub"].iter())
+        .token(vec!["https://www.googleapis.com/auth/pubsub"])
         .and_then(|tok| {
             println!("cached token is {:?} and should be identical", tok);
             Ok(())

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -64,7 +64,7 @@ where
 }
 
 /// An internal trait implemented by flows to be used by an authenticator.
-pub trait TokenGetterBuilder<C> {
+pub trait AuthFlow<C> {
     type TokenGetter: GetToken;
 
     fn build_token_getter(self, client: hyper::Client<C>) -> Self::TokenGetter;
@@ -74,7 +74,7 @@ pub trait TokenGetterBuilder<C> {
 /// will refresh tokens as they expire as well as optionally persist tokens to
 /// disk.
 pub struct Authenticator<
-    T: TokenGetterBuilder<C::Connector>,
+    T: AuthFlow<C::Connector>,
     S: TokenStorage,
     AD: AuthenticatorDelegate,
     C: HyperClientBuilder,
@@ -87,7 +87,7 @@ pub struct Authenticator<
 
 impl<T> Authenticator<T, MemoryStorage, DefaultAuthenticatorDelegate, DefaultHyperClient>
 where
-    T: TokenGetterBuilder<<DefaultHyperClient as HyperClientBuilder>::Connector>,
+    T: AuthFlow<<DefaultHyperClient as HyperClientBuilder>::Connector>,
 {
     /// Create a new authenticator with the provided flow. By default a new
     /// hyper::Client will be created the default authenticator delegate will be
@@ -115,7 +115,7 @@ where
 
 impl<T, S, AD, C> Authenticator<T, S, AD, C>
 where
-    T: TokenGetterBuilder<C::Connector>,
+    T: AuthFlow<C::Connector>,
     S: TokenStorage,
     AD: AuthenticatorDelegate,
     C: HyperClientBuilder,
@@ -127,7 +127,7 @@ where
     ) -> Authenticator<T, S, AD, hyper::Client<NewC>>
     where
         NewC: hyper::client::connect::Connect,
-        T: TokenGetterBuilder<NewC>,
+        T: AuthFlow<NewC>,
     {
         Authenticator {
             client: hyper_client,

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1,4 +1,4 @@
-use crate::authenticator_delegate::{AuthenticatorDelegate, Retry};
+use crate::authenticator_delegate::{AuthenticatorDelegate, DefaultAuthenticatorDelegate, Retry};
 use crate::refresh::RefreshFlow;
 use crate::storage::{hash_scopes, DiskTokenStorage, MemoryStorage, TokenStorage};
 use crate::types::{ApplicationSecret, GetToken, RefreshResult, RequestError, Token};
@@ -8,6 +8,7 @@ use tokio_timer;
 
 use std::error::Error;
 use std::io;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 /// Authenticator abstracts different `GetToken` implementations behind one type and handles
@@ -20,7 +21,7 @@ use std::sync::{Arc, Mutex};
 /// NOTE: It is recommended to use a client constructed like this in order to prevent functions
 /// like `hyper::run()` from hanging: `let client = hyper::Client::builder().keep_alive(false);`.
 /// Due to token requests being rare, this should not result in a too bad performance problem.
-pub struct Authenticator<
+struct AuthenticatorImpl<
     T: GetToken,
     S: TokenStorage,
     AD: AuthenticatorDelegate,
@@ -32,39 +33,156 @@ pub struct Authenticator<
     delegate: AD,
 }
 
-impl<T: GetToken, AD: AuthenticatorDelegate, C: hyper::client::connect::Connect>
-    Authenticator<T, MemoryStorage, AD, C>
+/// A trait implemented for any hyper::Client as well as teh DefaultHyperClient.
+pub trait HyperClientBuilder {
+    type Connector: hyper::client::connect::Connect;
+
+    fn build_hyper_client(self) -> hyper::Client<Self::Connector>;
+}
+
+/// The builder value used when the default hyper client should be used.
+pub struct DefaultHyperClient;
+impl HyperClientBuilder for DefaultHyperClient {
+    type Connector = hyper_rustls::HttpsConnector<hyper::client::connect::HttpConnector>;
+
+    fn build_hyper_client(self) -> hyper::Client<Self::Connector> {
+        hyper::Client::builder()
+            .keep_alive(false)
+            .build::<_, hyper::Body>(hyper_rustls::HttpsConnector::new(1))
+    }
+}
+
+impl<C> HyperClientBuilder for hyper::Client<C>
+where
+    C: hyper::client::connect::Connect,
 {
-    /// Create an Authenticator caching tokens for the duration of this authenticator.
+    type Connector = C;
+
+    fn build_hyper_client(self) -> hyper::Client<C> {
+        self
+    }
+}
+
+/// An internal trait implemented by flows to be used by an authenticator.
+pub trait TokenGetterBuilder<C> {
+    type TokenGetter: GetToken;
+
+    fn build_token_getter(self, client: hyper::Client<C>) -> Self::TokenGetter;
+}
+
+/// An authenticator can be used with `InstalledFlow`'s or `DeviceFlow`'s and
+/// will refresh tokens as they expire as well as optionally persist tokens to
+/// disk.
+pub struct Authenticator<
+    T: TokenGetterBuilder<C::Connector>,
+    S: TokenStorage,
+    AD: AuthenticatorDelegate,
+    C: HyperClientBuilder,
+> {
+    client: C,
+    token_getter: T,
+    store: io::Result<S>,
+    delegate: AD,
+}
+
+impl<T> Authenticator<T, MemoryStorage, DefaultAuthenticatorDelegate, DefaultHyperClient>
+where
+    T: TokenGetterBuilder<<DefaultHyperClient as HyperClientBuilder>::Connector>,
+{
+    /// Create a new authenticator with the provided flow. By default a new
+    /// hyper::Client will be created the default authenticator delegate will be
+    /// used, and tokens will not be persisted to disk.
+    /// Accepted flow types are DeviceFlow and InstalledFlow.
+    ///
+    /// Examples
+    /// ```
+    /// use std::path::Path;
+    /// use yup_oauth2::{ApplicationSecret, Authenticator, DeviceFlow};
+    /// let creds = ApplicationSecret::default();
+    /// let auth = Authenticator::new(DeviceFlow::new(creds)).build().unwrap();
+    /// ```
     pub fn new(
-        client: hyper::Client<C>,
-        inner: T,
-        delegate: AD,
-    ) -> Authenticator<T, MemoryStorage, AD, C> {
+        flow: T,
+    ) -> Authenticator<T, MemoryStorage, DefaultAuthenticatorDelegate, DefaultHyperClient> {
         Authenticator {
-            client: client,
-            inner: Arc::new(Mutex::new(inner)),
-            store: Arc::new(Mutex::new(MemoryStorage::new())),
-            delegate: delegate,
+            client: DefaultHyperClient,
+            token_getter: flow,
+            store: Ok(MemoryStorage::new()),
+            delegate: DefaultAuthenticatorDelegate,
         }
     }
 }
 
-impl<T: GetToken, AD: AuthenticatorDelegate, C: hyper::client::connect::Connect>
-    Authenticator<T, DiskTokenStorage, AD, C>
+impl<T, S, AD, C> Authenticator<T, S, AD, C>
+where
+    T: TokenGetterBuilder<C::Connector>,
+    S: TokenStorage,
+    AD: AuthenticatorDelegate,
+    C: HyperClientBuilder,
 {
-    /// Create an Authenticator using the store at `path`.
-    pub fn new_disk<P: AsRef<str>>(
-        client: hyper::Client<C>,
-        inner: T,
-        delegate: AD,
-        token_storage_path: P,
-    ) -> io::Result<Authenticator<T, DiskTokenStorage, AD, C>> {
-        Ok(Authenticator {
-            client: client,
-            inner: Arc::new(Mutex::new(inner)),
-            store: Arc::new(Mutex::new(DiskTokenStorage::new(token_storage_path)?)),
+    /// Use the provided hyper client.
+    pub fn hyper_client<NewC>(
+        self,
+        hyper_client: hyper::Client<NewC>,
+    ) -> Authenticator<T, S, AD, hyper::Client<NewC>>
+    where
+        NewC: hyper::client::connect::Connect,
+        T: TokenGetterBuilder<NewC>,
+    {
+        Authenticator {
+            client: hyper_client,
+            token_getter: self.token_getter,
+            store: self.store,
+            delegate: self.delegate,
+        }
+    }
+
+    /// Persist tokens to disk in the provided filename.
+    pub fn persist_tokens_to_disk<P: AsRef<Path>>(
+        self,
+        path: P,
+    ) -> Authenticator<T, DiskTokenStorage, AD, C> {
+        let disk_storage = DiskTokenStorage::new(path.as_ref().to_str().unwrap());
+        Authenticator {
+            client: self.client,
+            token_getter: self.token_getter,
+            store: disk_storage,
+            delegate: self.delegate,
+        }
+    }
+
+    /// Use the provided authenticator delegate.
+    pub fn delegate<NewAD: AuthenticatorDelegate>(
+        self,
+        delegate: NewAD,
+    ) -> Authenticator<T, S, NewAD, C> {
+        Authenticator {
+            client: self.client,
+            token_getter: self.token_getter,
+            store: self.store,
             delegate: delegate,
+        }
+    }
+
+    /// Create the authenticator.
+    pub fn build(self) -> io::Result<impl GetToken>
+    where
+        T::TokenGetter: 'static + GetToken + Send,
+        S: 'static + Send,
+        AD: 'static + Send,
+        C::Connector: 'static + Clone + Send,
+    {
+        let client = self.client.build_hyper_client();
+        let store = Arc::new(Mutex::new(self.store?));
+        let inner = Arc::new(Mutex::new(
+            self.token_getter.build_token_getter(client.clone()),
+        ));
+
+        Ok(AuthenticatorImpl {
+            client,
+            inner,
+            store,
+            delegate: self.delegate,
         })
     }
 }
@@ -74,7 +192,7 @@ impl<
         S: 'static + TokenStorage + Send,
         AD: 'static + AuthenticatorDelegate + Send,
         C: 'static + hyper::client::connect::Connect + Clone + Send,
-    > GetToken for Authenticator<GT, S, AD, C>
+    > GetToken for AuthenticatorImpl<GT, S, AD, C>
 {
     /// Returns the API Key of the inner flow.
     fn api_key(&mut self) -> Option<String> {

--- a/src/device.rs
+++ b/src/device.rs
@@ -73,7 +73,7 @@ impl<FD> DeviceFlow<FD> {
     }
 }
 
-impl<FD, C> crate::authenticator::TokenGetterBuilder<C> for DeviceFlow<FD>
+impl<FD, C> crate::authenticator::AuthFlow<C> for DeviceFlow<FD>
 where
     FD: FlowDelegate + Send + 'static,
     C: hyper::client::connect::Connect + 'static,
@@ -407,7 +407,7 @@ mod tests {
     use tokio;
 
     use super::*;
-    use crate::authenticator::TokenGetterBuilder;
+    use crate::authenticator::AuthFlow;
     use crate::helper::parse_application_secret;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ mod service_account;
 mod storage;
 mod types;
 
-pub use crate::authenticator::Authenticator;
+pub use crate::authenticator::{AuthFlow, Authenticator};
 pub use crate::authenticator_delegate::{
     AuthenticatorDelegate, DefaultAuthenticatorDelegate, DefaultFlowDelegate, FlowDelegate,
     PollInformation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,41 +48,22 @@
 //! use std::path::Path;
 //!
 //! fn main() {
-//!     // Boilerplate: Set up hyper HTTP client and TLS.
-//!     let https = HttpsConnector::new(1);
-//!     let client = Client::builder()
-//!         .keep_alive(false)
-//!         .build::<_, hyper::Body>(https);
-//!
 //!     // Read application secret from a file. Sometimes it's easier to compile it directly into
 //!     // the binary. The clientsecret file contains JSON like `{"installed":{"client_id": ... }}`
 //!     let secret = yup_oauth2::read_application_secret(Path::new("clientsecret.json"))
 //!         .expect("clientsecret.json");
 //!
-//!     // There are two types of delegates; FlowDelegate and AuthenticatorDelegate. See the
-//!     // respective documentation; all you need to know here is that they determine how the user
-//!     // is asked to visit the OAuth flow URL or how to read back the provided code.
-//!     let ad = yup_oauth2::DefaultFlowDelegate;
-//!
-//!     // InstalledFlow handles OAuth flows of that type. They are usually the ones where a user
-//!     // grants access to their personal account (think Google Drive, Github API, etc.).
-//!     let inf = InstalledFlow::new(
-//!         client.clone(),
-//!         ad,
-//!         secret,
-//!         yup_oauth2::InstalledFlowReturnMethod::HTTPRedirectEphemeral,
-//!     );
-//!     // You could already use InstalledFlow by itself, but usually you want to cache tokens and
-//!     // refresh them, rather than ask the user every time to log in again. Authenticator wraps
-//!     // other flows and handles these.
-//!     // This type of authenticator caches tokens in a JSON file on disk.
-//!     let mut auth = Authenticator::new_disk(
-//!         client,
-//!         inf,
-//!         yup_oauth2::DefaultAuthenticatorDelegate,
-//!         "tokencache.json",
+//!     // Create an authenticator that uses an InstalledFlow to authenticate. The
+//!      // authentication tokens are persisted to a file named tokencache.json. The
+//!      // authenticator takes care of caching tokens to disk and refreshing tokens once
+//!      // they've expired.
+//!     let mut auth = Authenticator::new(
+//!         InstalledFlow::new(secret, yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect(0))
 //!     )
+//!     .persist_tokens_to_disk("tokencache.json")
+//!     .build()
 //!     .unwrap();
+//!
 //!     let s = "https://www.googleapis.com/auth/drive.file".to_string();
 //!     let scopes = vec![s];
 //!


### PR DESCRIPTION
Beyond simply moving to the builder pattern for intialization this has a
few other effects.

The DeviceFlow and InstalledFlow can no longer be used without an
associated Authenticator. This is becaus they no longer have any
publicly accessible constructor. All initialization goes through the
Authenticator. This also means that the flows are always initialized
with a clone of the hyper client used by the Authenticator.

The authenticator uses the builder pattern which allows omitting
optional fields. This means that if users simply want a default hyper
client, they don't need to create one explicitly. One will be created
automatically. If users want to specify a hyper client (maybe to allow
sharing a single client between different libraries) they can still do so
by using the hyper_client method on the builder. Additionally for both
AuthenticatorDelegate's and FlowDelegate's if the user does not specify
an override the default ones will be used.

The builders are now exposed publicly with the names of Authenicator,
InstalledFlow, and DeviceFlow. The structs that actually implement those
behaviors are now hidden and only expose the GetToken trait. This means
some methods that were previously publicly accessible are no longer
available, but the methods appeared to be implementation details that
probably shouldn't have been exposed anyway.