### PR TITLE
Make RequestError Sync

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 /// For completeness, the underlying, sorted scopes are provided as well. They might be
 /// useful for presentation to the user.
 pub trait TokenStorage {
-    type Error: 'static + Error + Send;
+    type Error: 'static + Error + Send + Sync;
 
     /// If `token` is None, it is invalid or revoked and should be removed from storage.
     /// Otherwise, it should be saved.

--- a/src/types.rs
+++ b/src/types.rs
@@ -71,7 +71,7 @@ pub enum RequestError {
     /// An error occurred while refreshing tokens.
     Refresh(RefreshResult),
     /// Error in token cache layer
-    Cache(Box<dyn Error + Send>),
+    Cache(Box<dyn Error + Send + Sync>),
 }
 
 impl From<hyper::Error> for RequestError {


### PR DESCRIPTION
This requires enforcing that errors returned from TokenStorage
implementations are Send, which the ones in this crate are, but is a
breaking change because any external implementations may be returning
errors that are !Sync currently.

The motivation for this change is that Box<dyn Error + Send> is not as fully
supported within the rust stdlib as Box<dyn Error + Send + Sync>. In
particular there exists these two From impls:

impl<'a, E: Error + 'a> From<E> for Box<dyn Error + 'a>
impl<'a, E: Error + Send + Sync + 'a> From<E> for Box<dyn Error + Send + Sync + 'a>

but no corresponding impl for

impl<'a, E: Error + Send + 'a> From<E> for Box<dyn Error + Send + 'a>

This may just be an oversight in the rust stdlib that could be fixed,
but in practice it means that dealing with 'Error + Send' types is not
the most ergonomic because the '?' operator can't be used to convert
from a Box<dyn Error + Send> to a Box<dyn Error>.

Since the current implementations (not counting any external ones that
may exist) implement Sync this seems like a good tradeoff to make it a
little easier to use in an ergonomic way.