### PR TITLE
make refresh_token an option

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -237,7 +237,7 @@ impl<
                     let refresh_fut = RefreshFlow::refresh_token(
                         client.clone(),
                         appsecret.clone(),
-                        refresh_token,
+                        refresh_token.unwrap(),
                     )
                         .and_then(move |rr| -> Box<dyn Future<Item=future::Loop<Token, ()>, Error=RequestError> + Send> {
                             match rr {

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -669,7 +669,7 @@ mod tests {
                 .token(vec!["https://googleapis.com/some/scope"])
                 .and_then(|tok| {
                     assert_eq!("accesstoken", tok.access_token);
-                    assert_eq!("refreshtoken", tok.refresh_token);
+                    assert_eq!("refreshtoken", tok.refresh_token.unwrap());
                     assert_eq!("Bearer", tok.token_type);
                     Ok(())
                 });
@@ -695,7 +695,7 @@ mod tests {
                 .token(vec!["https://googleapis.com/some/scope"])
                 .and_then(|tok| {
                     assert_eq!("accesstoken", tok.access_token);
-                    assert_eq!("refreshtoken", tok.refresh_token);
+                    assert_eq!("refreshtoken", tok.refresh_token.unwrap());
                     assert_eq!("Bearer", tok.token_type);
                     Ok(())
                 });

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -242,7 +242,7 @@ impl<'c, FD: 'static + FlowDelegate + Clone + Send, C: 'c + hyper::client::conne
                 if tokens.access_token.is_some() {
                     let mut token = Token {
                         access_token: tokens.access_token.unwrap(),
-                        refresh_token: tokens.refresh_token.unwrap(),
+                        refresh_token: Some(tokens.refresh_token.unwrap()),
                         token_type: tokens.token_type.unwrap(),
                         expires_in: tokens.expires_in,
                         expires_in_timestamp: None,

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -91,7 +91,7 @@ impl RefreshFlow {
                 Ok(RefreshResult::Success(Token {
                     access_token: t.access_token,
                     token_type: t.token_type,
-                    refresh_token: refresh_token.to_string(),
+                    refresh_token: Some(refresh_token.to_string()),
                     expires_in: None,
                     expires_in_timestamp: Some(Utc::now().timestamp() + t.expires_in),
                 }))

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -273,7 +273,7 @@ impl TokenResponse {
         Token {
             access_token: self.access_token.unwrap(),
             token_type: self.token_type.unwrap(),
-            refresh_token: String::new(),
+            refresh_token: Some(String::new()),
             expires_in: self.expires_in,
             expires_in_timestamp: Some(expires_ts),
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -207,7 +207,7 @@ impl DiskTokenStorage {
             jsontokens.tokens.push((*token).clone());
         }
 
-        let serialized;;
+        let serialized;
 
         match serde_json::to_string(&jsontokens) {
             Result::Err(e) => return Result::Err(io::Error::new(io::ErrorKind::InvalidData, e)),

--- a/src/types.rs
+++ b/src/types.rs
@@ -272,7 +272,7 @@ pub struct Token {
     /// used when authenticating calls to oauth2 enabled services.
     pub access_token: String,
     /// used to refresh an expired access_token.
-    pub refresh_token: String,
+    pub refresh_token: Option<String>,
     /// The token type as string - usually 'Bearer'.
     pub token_type: String,
     /// access_token will expire after this amount of time.


### PR DESCRIPTION
Azure is not returning a refresh_token. With this change and a hard-coded grant_type #113. I'm able to do run the test-device example with Azure.

The error that this resolves is:
```
thread 'tokio-runtime-worker-1' panicked at 'called `Result::unwrap()` on an `Err` value: Error("missing field `refresh_token`", line: 1, column: 3313)', src/libcore/result.rs:1165:5
```