### PR TITLE
Expose default authenticator type

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -454,6 +454,10 @@ pub trait HyperClientBuilder {
     fn build_hyper_client(self) -> hyper::Client<Self::Connector>;
 }
 
+/// Default authenticator type
+pub type DefaultAuthenticator =
+    Authenticator<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>;
+
 /// The builder value used when the default hyper client should be used.
 pub struct DefaultHyperClient;
 impl HyperClientBuilder for DefaultHyperClient {


### PR DESCRIPTION
# Motivation

It's inconvenient for downstream consumers to require a direct dependency on `hyper` & `hyper-rustls` just to define a full `Authenticator` struct.

# Solution

This PR exposes a `DefaultAuthenticator` type, which is defined as `Authenticator<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>`.

This allows consumers to write

```rust
struct MyClient {
    auth: yup_oauth2::authenticator::DefaultAuthenticator,
    ...
}
```

rather than

```rust
struct MyClient {
    auth: yup_oauth2::authenticator::Authenticator<
        hyper_rustls::HttpsConnector<hyper::client::HttpConnector>,
    >,
    ...
}
```