### PR TITLE
open webbrowser with url for the user

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ tokio = { version = "0.2", features = ["fs", "macros", "io-std", "time"] }
 url = "2"
 percent-encoding = "2"
 futures = "0.3"
+webbrowser = "0.5"
 
 [dev-dependencies]
 httptest = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,12 @@ tokio = { version = "0.2", features = ["fs", "macros", "io-std", "time"] }
 url = "2"
 percent-encoding = "2"
 futures = "0.3"
-webbrowser = "0.5"
 
 [dev-dependencies]
 httptest = "0.11.1"
 env_logger = "0.7"
 tempfile = "3.1"
+webbrowser = "0.5"
 
 [workspace]
 members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/service_account"]

--- a/examples/custom_flow.rs
+++ b/examples/custom_flow.rs
@@ -6,16 +6,17 @@
 //! paste needed to continue with the operation.
 use std::future::Future;
 use std::pin::Pin;
-use yup_oauth2::authenticator_delegate::{present_user_url, InstalledFlowDelegate};
+use yup_oauth2::authenticator_delegate::{DefaultInstalledFlowDelegate, InstalledFlowDelegate};
 
 /// async function to be pinned by the `present_user_url` method of the trait
-/// we use the existing `authenticator_delegate::present_user_url` function as a fallback for
+/// we use the existing `DefaultInstalledFlowDelegate::present_user_url` method as a fallback for
 /// when the browser did not open for example, the user still see's the URL.
 async fn browser_user_url(url: &str, need_code: bool) -> Result<String, String> {
     if webbrowser::open(url).is_ok() {
         println!("webbrowser was successfully opened.");
     }
-    present_user_url(url, need_code).await
+    let def_delegate = DefaultInstalledFlowDelegate;
+    def_delegate.present_user_url(url, need_code).await
 }
 
 /// our custom delegate struct we will implement a flow delegate trait for:

--- a/examples/custom_flow.rs
+++ b/examples/custom_flow.rs
@@ -48,6 +48,7 @@ async fn main() {
         yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
     )
     .persist_tokens_to_disk("tokencache.json")
+    // use our custom flow delegate instead of default
     .flow_delegate(Box::new(InstalledFlowBrowserDelegate))
     .build()
     .await

--- a/examples/custom_flow.rs
+++ b/examples/custom_flow.rs
@@ -1,0 +1,62 @@
+//! Demonstrating how to create a custom Flow
+//! here we open the browser for the user, making the use of InstalledAppFlow more convenient as
+//! nothing has to be copy/pasted. Reason, the browser will open, the user accepts the requested
+//! scope by clicking through e.g. the google oauth2, after this is done a local webserver started
+//! by InstalledFlowAuthenticator will consume the token coming from the oauth2 server = no copy or
+//! paste needed to continue with the operation.
+use std::future::Future;
+use std::pin::Pin;
+use yup_oauth2::authenticator_delegate::{present_user_url, InstalledFlowDelegate};
+
+/// async function to be pinned by the `present_user_url` method of the trait
+/// we use the existing `authenticator_delegate::present_user_url` function as a fallback for
+/// when the browser did not open for example, the user still see's the URL.
+async fn browser_user_url(url: &str, need_code: bool) -> Result<String, String> {
+    if webbrowser::open(url).is_ok() {
+        println!("webbrowser was successfully opened.");
+    }
+    present_user_url(url, need_code).await
+}
+
+/// our custom delegate struct we will implement a flow delegate trait for:
+/// in this case we will implement the `InstalledFlowDelegated` trait
+#[derive(Copy, Clone)]
+struct InstalledFlowBrowserDelegate;
+
+/// here we implement only the present_user_url method with the added webbrowser opening
+/// the other behaviour of the trait does not need to be changed.
+impl InstalledFlowDelegate for InstalledFlowBrowserDelegate {
+    /// the actual presenting of URL and browser opening happens in the function defined above here
+    /// we only pin it
+    fn present_user_url<'a>(
+        &'a self,
+        url: &'a str,
+        need_code: bool,
+    ) -> Pin<Box<dyn Future<Output = Result<String, String>> + Send + 'a>> {
+        Box::pin(browser_user_url(url, need_code))
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    // Put your client secret in the working directory!
+    let sec = yup_oauth2::read_application_secret("client_secret.json")
+        .await
+        .expect("client secret couldn't be read.");
+    let auth = yup_oauth2::InstalledFlowAuthenticator::builder(
+        sec,
+        yup_oauth2::InstalledFlowReturnMethod::HTTPRedirect,
+    )
+    .persist_tokens_to_disk("tokencache.json")
+    .flow_delegate(Box::new(InstalledFlowBrowserDelegate))
+    .build()
+    .await
+    .expect("InstalledFlowAuthenticator failed to build");
+
+    let scopes = &["https://www.googleapis.com/auth/drive.file"];
+
+    match auth.token(scopes).await {
+        Err(e) => println!("error: {:?}", e),
+        Ok(t) => println!("The token is {:?}", t),
+    }
+}

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -128,6 +128,9 @@ async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> 
              code displayed here: ",
             url
         );
+        if webbrowser::open(url).is_ok() {
+            println!("webbrowser was successfully opened.");
+        }
         let mut user_input = String::new();
         tokio::io::BufReader::new(tokio::io::stdin())
             .read_line(&mut user_input)
@@ -142,6 +145,9 @@ async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> 
              there.",
             url
         );
+        if webbrowser::open(url).is_ok() {
+            println!("webbrowser was successfully opened.");
+        }
         Ok(String::new())
     }
 }

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -120,7 +120,8 @@ pub trait InstalledFlowDelegate: Send + Sync {
     }
 }
 
-async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> {
+/// Used for FlowDelegates to ask user to open URL.
+pub async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> {
     use tokio::io::AsyncBufReadExt;
     if need_code {
         println!(
@@ -128,9 +129,6 @@ async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> 
              code displayed here: ",
             url
         );
-        if webbrowser::open(url).is_ok() {
-            println!("webbrowser was successfully opened.");
-        }
         let mut user_input = String::new();
         tokio::io::BufReader::new(tokio::io::stdin())
             .read_line(&mut user_input)
@@ -145,9 +143,6 @@ async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> 
              there.",
             url
         );
-        if webbrowser::open(url).is_ok() {
-            println!("webbrowser was successfully opened.");
-        }
         Ok(String::new())
     }
 }

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -120,8 +120,7 @@ pub trait InstalledFlowDelegate: Send + Sync {
     }
 }
 
-/// Used for FlowDelegates to ask user to open URL.
-pub async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> {
+async fn present_user_url(url: &str, need_code: bool) -> Result<String, String> {
     use tokio::io::AsyncBufReadExt;
     if need_code {
         println!(


### PR DESCRIPTION
googles python api has that as an option. very convenient as the auth URL doesn't have to be copied from terminal, especially with the installed-app-flow no copy/paste needed, ever.

this is a quickhack showing it works in rust too. I guess you might want to make this optional somehow?
Please let me know how to integrate this for your library.