### PR TITLE
Bump to tokio 1.0 and hyper 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,20 @@ edition = "2018"
 base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
-hyper = { git = "https://github.com/hyperium/hyper" }
-hyper-rustls = { git = "https://github.com/messense/hyper-rustls", branch = "tokio-0-3" }
+hyper = { version = "0.14", features = ["client", "server", "tcp", "http2"] }
+hyper-rustls = { git = "https://github.com/ctz/hyper-rustls" }
 log = "0.4"
-rustls = "0.18"
+rustls = "0.19"
 seahash = "4"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-tokio = { version = "0.3", features = ["fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
+tokio = { version = "1.0", features = ["fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
 url = "2"
 percent-encoding = "2"
 futures = "0.3"
 
 [dev-dependencies]
-httptest = { git = "https://github.com/maximebedard/httptest", branch = "bump-tokio-hyper" }
+httptest = { git = "https://github.com/ggriffiniii/httptest" }
 env_logger = "0.7"
 tempfile = "3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "server", "tcp", "http2"] }
-hyper-rustls = { git = "https://github.com/ctz/hyper-rustls" }
+hyper-rustls = "0.22"
 log = "0.4"
 rustls = "0.19"
 seahash = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ percent-encoding = "2"
 futures = "0.3"
 
 [dev-dependencies]
-httptest = { git = "https://github.com/ggriffiniii/httptest" }
+httptest = "0.14"
 env_logger = "0.7"
 tempfile = "3.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,20 @@ edition = "2018"
 base64 = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
-hyper = "0.13.5"
-hyper-rustls = "0.20"
+hyper = { git = "https://github.com/hyperium/hyper" }
+hyper-rustls = { git = "https://github.com/messense/hyper-rustls", branch = "tokio-0-3" }
 log = "0.4"
-rustls = "0.17"
+rustls = "0.18"
 seahash = "4"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-tokio = { version = "0.2", features = ["fs", "macros", "io-std", "time"] }
+tokio = { version = "0.3", features = ["fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
 url = "2"
 percent-encoding = "2"
 futures = "0.3"
 
 [dev-dependencies]
-httptest = "0.11.1"
+httptest = { git = "https://github.com/maximebedard/httptest", branch = "bump-tokio-hyper" }
 env_logger = "0.7"
 tempfile = "3.1"
 

--- a/examples/test-device/Cargo.toml
+++ b/examples/test-device/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 yup-oauth2 = { path = "../../" }
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/test-device/Cargo.toml
+++ b/examples/test-device/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 yup-oauth2 = { path = "../../" }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/examples/test-installed/Cargo.toml
+++ b/examples/test-installed/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 yup-oauth2 = { path = "../../" }
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/test-installed/Cargo.toml
+++ b/examples/test-installed/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 yup-oauth2 = { path = "../../" }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/examples/test-svc-acct/Cargo.toml
+++ b/examples/test-svc-acct/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 yup-oauth2 = { path = "../../" }
-tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/test-svc-acct/Cargo.toml
+++ b/examples/test-svc-acct/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 yup-oauth2 = { path = "../../" }
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -466,7 +466,7 @@ impl HyperClientBuilder for DefaultHyperClient {
     fn build_hyper_client(self) -> hyper::Client<Self::Connector> {
         hyper::Client::builder()
             .pool_max_idle_per_host(0)
-            .build::<_, hyper::Body>(hyper_rustls::HttpsConnector::new())
+            .build::<_, hyper::Body>(hyper_rustls::HttpsConnector::with_native_roots())
     }
 }
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -80,7 +80,7 @@ impl DeviceFlow {
         let mut interval = device_auth_resp.interval;
         log::debug!("Polling every {:?} for device token", interval);
         loop {
-            tokio::time::delay_for(interval).await;
+            tokio::time::sleep(interval).await;
             interval = match Self::poll_token(
                 &app_secret,
                 hyper_client,

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -225,7 +225,7 @@ mod tests {
             .await
             .unwrap();
         let acc = ServiceAccountFlow::new(ServiceAccountFlowOpts { key, subject: None }).unwrap();
-        let https = HttpsConnector::new();
+        let https = HttpsConnector::with_native_roots();
         let client = hyper::Client::builder()
             .pool_max_idle_per_host(0)
             .build::<_, hyper::Body>(https);

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -227,7 +227,7 @@ mod tests {
         let acc = ServiceAccountFlow::new(ServiceAccountFlowOpts { key, subject: None }).unwrap();
         let https = HttpsConnector::new();
         let client = hyper::Client::builder()
-            .keep_alive(false)
+            .pool_max_idle_per_host(0)
             .build::<_, hyper::Body>(https);
         println!(
             "{:?}",

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 
-use httptest::{mappers::*, responders::json_encoded, Expectation, Server};
+use httptest::{matchers::*, responders::json_encoded, Expectation, Server};
 use hyper::client::connect::HttpConnector;
 use hyper::Uri;
 use hyper_rustls::HttpsConnector;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -216,7 +216,7 @@ async fn create_installed_flow_auth(
     }
 
     let mut builder = InstalledFlowAuthenticator::builder(app_secret, method).flow_delegate(
-        Box::new(FD(hyper::Client::builder().build(HttpsConnector::new()))),
+        Box::new(FD(hyper::Client::builder().build(HttpsConnector::with_native_roots()))),
     );
 
     builder = if let Some(filename) = filename {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -215,9 +215,10 @@ async fn create_installed_flow_auth(
         }
     }
 
-    let mut builder = InstalledFlowAuthenticator::builder(app_secret, method).flow_delegate(
-        Box::new(FD(hyper::Client::builder().build(HttpsConnector::with_native_roots()))),
-    );
+    let mut builder =
+        InstalledFlowAuthenticator::builder(app_secret, method).flow_delegate(Box::new(FD(
+            hyper::Client::builder().build(HttpsConnector::with_native_roots()),
+        )));
 
     builder = if let Some(filename) = filename {
         builder.persist_tokens_to_disk(filename)


### PR DESCRIPTION
Depends on https://github.com/ggriffiniii/httptest/pull/6 and https://github.com/hyperium/hyper-tls/pull/78. Will wait for version 0.14 of hyper to be pushed to crates.io and update this PR afterward with the actual release.