### PR TITLE
Draft: feat: introduce an optional hyper-tls dependency, closes  #143

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,16 @@ keywords = ["google", "oauth", "v2"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[features]
+default = ["hyper-rustls"]
+
 [dependencies]
-base64 = "0.12"
+base64 = "0.13.0"
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "server", "tcp", "http2"] }
-hyper-rustls = "0.22.1"
+hyper-rustls = { version = "0.22.1", optional = true }
+hyper-tls = { version = "0.5.0", optional = true }
 log = "0.4"
 rustls = "0.19"
 seahash = "4"

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -454,19 +454,32 @@ pub trait HyperClientBuilder {
     fn build_hyper_client(self) -> hyper::Client<Self::Connector>;
 }
 
+#[cfg(not(feature = "hyper-tls"))]
 /// Default authenticator type
 pub type DefaultAuthenticator =
     Authenticator<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>;
+#[cfg(feature = "hyper-tls")]
+/// Default authenticator type
+pub type DefaultAuthenticator =
+    Authenticator<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>;
 
 /// The builder value used when the default hyper client should be used.
 pub struct DefaultHyperClient;
 impl HyperClientBuilder for DefaultHyperClient {
+    #[cfg(not(feature = "hyper-tls"))]
     type Connector = hyper_rustls::HttpsConnector<hyper::client::connect::HttpConnector>;
+    #[cfg(feature = "hyper-tls")]
+    type Connector = hyper_tls::HttpsConnector<hyper::client::connect::HttpConnector>;
 
     fn build_hyper_client(self) -> hyper::Client<Self::Connector> {
+        #[cfg(not(feature = "hyper-tls"))]
+        let connector = hyper_rustls::HttpsConnector::with_native_roots();
+        #[cfg(feature = "hyper-tls")]
+        let connector = hyper_tls::HttpsConnector::new();
+
         hyper::Client::builder()
             .pool_max_idle_per_host(0)
-            .build::<_, hyper::Body>(hyper_rustls::HttpsConnector::with_native_roots())
+            .build::<_, hyper::Body>(connector)
     }
 }
 

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -212,7 +212,10 @@ impl ServiceAccountFlow {
 mod tests {
     use super::*;
     use crate::helper::read_service_account_key;
+    #[cfg(not(feature = "hyper-tls"))]
     use hyper_rustls::HttpsConnector;
+    #[cfg(feature = "hyper-tls")]
+    use hyper_tls::HttpsConnector;
 
     // Valid but deactivated key.
     const TEST_PRIVATE_KEY_PATH: &'static str = "examples/Sanguine-69411a0c0eea.json";
@@ -225,7 +228,10 @@ mod tests {
             .await
             .unwrap();
         let acc = ServiceAccountFlow::new(ServiceAccountFlowOpts { key, subject: None }).unwrap();
+        #[cfg(not(feature = "hyper-tls"))]
         let https = HttpsConnector::with_native_roots();
+        #[cfg(feature = "hyper-tls")]
+        let https = HttpsConnector::new();
         let client = hyper::Client::builder()
             .pool_max_idle_per_host(0)
             .build::<_, hyper::Body>(https);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -13,7 +13,10 @@ use std::pin::Pin;
 use httptest::{matchers::*, responders::json_encoded, Expectation, Server};
 use hyper::client::connect::HttpConnector;
 use hyper::Uri;
+#[cfg(not(feature = "hyper-tls"))]
 use hyper_rustls::HttpsConnector;
+#[cfg(feature = "hyper-tls")]
+use hyper_tls::HttpsConnector;
 use url::form_urlencoded;
 
 /// Utility function for parsing json. Useful in unit tests. Simply wrap the
@@ -217,7 +220,10 @@ async fn create_installed_flow_auth(
 
     let mut builder =
         InstalledFlowAuthenticator::builder(app_secret, method).flow_delegate(Box::new(FD(
+            #[cfg(not(feature = "hyper-tls"))]
             hyper::Client::builder().build(HttpsConnector::with_native_roots()),
+            #[cfg(feature = "hyper-tls")]
+            hyper::Client::builder().build(HttpsConnector::new()),
         )));
 
     builder = if let Some(filename) = filename {


### PR DESCRIPTION
For the most part, everything maps pretty straightforwardly to hyper-tls. The one area I wasn't sure of was how to replace the HttpsConnector::with_native_roots() methods in hyper-rustls. I would love some feedback on this.