### PR TITLE
--all-features and --no-default-features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,44 @@ name: Actions CI
 
 jobs:
   build_and_test:
-    name: yup-oauth2 
+    name: yup-oauth2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          profile: minimal
+          default: true
       - uses: actions-rs/cargo@v1
         with:
           command: test
       - uses: actions-rs/cargo@v1
         with:
+          command: test
+          args: --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --tests --examples
+      - uses: actions-rs/cargo@v1
+        with:
           command: build
           args: --examples
+
+  doc:
+    name: yup-oauth2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --all-features
+        env:
+          RUSTDOCFLAGS: --cfg yup_oauth2_docsrs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ jobs:
   build_and_test:
     name: yup-oauth2
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features: ["hyper-rustls", "hyper-tls", "hyper-rustls,hyper-tls", ""]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -16,18 +20,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features --tests --examples
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --examples
+          args: --no-default-features --features=${{ matrix.features }}
 
   doc:
     name: yup-oauth2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ required-features = ["hyper-rustls"]
 name = "tests"
 required-features = ["hyper-rustls"]
 
-
 [features]
 default = ["hyper-rustls"]
 
@@ -47,6 +46,7 @@ httptest = "0.14"
 env_logger = "0.7"
 tempfile = "3.1"
 webbrowser = "0.5"
+hyper-rustls = "0.22.1"
 
 [workspace]
 members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/service_account", "examples/drive_example"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ edition = "2018"
 name = "custom_flow"
 required-features = ["hyper-rustls"]
 
+[[example]]
+name = "custom_storage"
+required-features = ["hyper-rustls"]
+
 [[test]]
 name = "tests"
 required-features = ["hyper-rustls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ keywords = ["google", "oauth", "v2"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+[[example]]
+name = "custom_flow"
+required-features = ["hyper-rustls"]
+
+[[test]]
+name = "tests"
+required-features = ["hyper-rustls"]
+
+
 [features]
 default = ["hyper-rustls"]
 
@@ -41,3 +50,7 @@ webbrowser = "0.5"
 
 [workspace]
 members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/service_account", "examples/drive_example"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "yup_oauth2_docsrs"]

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -1,0 +1,43 @@
+//! This example demonstrates how to use the same connection pool for both obtaining the tokens and
+//! using the API that these tokens authorize. In most cases e.g. obtaining the service account key
+//! will already establish a keep-alive http connection, so the succeeding API call should be much
+//! faster.
+//!
+//! It is also a better use of resources (memory, sockets, etc.)
+
+async fn r#use<C>(
+    client: hyper::Client<C>,
+    authenticator: yup_oauth2::authenticator::Authenticator<C>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    C: Clone + Send + Sync + hyper::client::connect::Connect + 'static,
+{
+    let token = authenticator.token(&["email"]).await?;
+    let request = http::Request::get("https://example.com")
+        .header(
+            http::header::AUTHORIZATION,
+            format!("Bearer {}", token.as_str()),
+        )
+        .body(hyper::body::Body::empty())?;
+    let response = client.request(request).await?;
+    drop(response); // Implementing handling of the response is left as an exercise for the reader.
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() {
+    let google_credentials = std::env::var("GOOGLE_APPLICATION_CREDENTIALS")
+        .expect("env var GOOGLE_APPLICATION_CREDENTIALS is required");
+    let secret = yup_oauth2::read_service_account_key(google_credentials)
+        .await
+        .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
+    let client = hyper::Client::builder().build(hyper_rustls::HttpsConnector::with_native_roots());
+    let authenticator =
+        yup_oauth2::ServiceAccountAuthenticator::with_client(secret, client.clone())
+            .build()
+            .await
+            .expect("could not create an authenticator");
+    r#use(client, authenticator)
+        .await
+        .expect("use is successful!");
+}

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -141,6 +141,7 @@ pub struct AuthenticatorBuilder<C, F> {
 
 /// Create an authenticator that uses the installed flow.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # use yup_oauth2::InstalledFlowReturnMethod;
 /// # let custom_flow_delegate = yup_oauth2::authenticator_delegate::DefaultInstalledFlowDelegate;
@@ -181,6 +182,7 @@ impl InstalledFlowAuthenticator {
 
 /// Create an authenticator that uses the device flow.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # let app_secret = yup_oauth2::read_application_secret("/tmp/foo").await.unwrap();
 ///     let authenticator = yup_oauth2::DeviceFlowAuthenticator::builder(app_secret)
@@ -214,6 +216,7 @@ impl DeviceFlowAuthenticator {
 
 /// Create an authenticator that uses a service account.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # let service_account_key = yup_oauth2::read_service_account_key("/tmp/foo").await.unwrap();
 ///     let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(service_account_key)
@@ -253,6 +256,7 @@ impl ServiceAccountAuthenticator {
 
 /// ## Methods available when building any Authenticator.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # let custom_hyper_client = hyper::Client::new();
 /// # let app_secret = yup_oauth2::read_application_secret("/tmp/foo").await.unwrap();
@@ -330,6 +334,7 @@ impl<C, F> AuthenticatorBuilder<C, F> {
 
 /// ## Methods available when building a device flow Authenticator.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # let custom_flow_delegate = yup_oauth2::authenticator_delegate::DefaultDeviceFlowDelegate;
 /// # let app_secret = yup_oauth2::read_application_secret("/tmp/foo").await.unwrap();
@@ -392,6 +397,7 @@ impl<C> AuthenticatorBuilder<C, DeviceFlow> {
 
 /// ## Methods available when building an installed flow Authenticator.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # use yup_oauth2::InstalledFlowReturnMethod;
 /// # let custom_flow_delegate = yup_oauth2::authenticator_delegate::DefaultInstalledFlowDelegate;
@@ -434,6 +440,7 @@ impl<C> AuthenticatorBuilder<C, InstalledFlow> {
 
 /// ## Methods available when building a service account authenticator.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
 /// # let service_account_key = yup_oauth2::read_service_account_key("/tmp/foo").await.unwrap();
 ///     let authenticator = yup_oauth2::ServiceAccountAuthenticator::builder(
@@ -597,10 +604,10 @@ enum StorageType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     #[test]
     #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
     fn ensure_send_sync() {
+        use super::*;
         fn is_send_sync<T: Send + Sync>() {}
         is_send_sync::<Authenticator<<DefaultHyperClient as HyperClientBuilder>::Connector>>()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,8 +8,9 @@ use std::io;
 use serde::Deserialize;
 
 /// Error returned by the authorization server.
-/// https://tools.ietf.org/html/rfc6749#section-5.2
-/// https://tools.ietf.org/html/rfc8628#section-3.5
+///
+/// <https://tools.ietf.org/html/rfc6749#section-5.2>
+/// <https://tools.ietf.org/html/rfc8628#section-3.5>
 #[derive(Deserialize, Debug, PartialEq, Eq)]
 pub struct AuthError {
     /// Error code from the server.

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -60,7 +60,9 @@ where
     })
 }
 
-/// cf. https://developers.google.com/identity/protocols/OAuth2InstalledApp#choosingredirecturi
+/// Method by which the user agent return token to this application.
+///
+/// cf. <https://developers.google.com/identity/protocols/OAuth2InstalledApp#choosingredirecturi>
 pub enum InstalledFlowReturnMethod {
     /// Involves showing a URL to the user and asking to copy a code from their browser
     /// (default)
@@ -71,8 +73,8 @@ pub enum InstalledFlowReturnMethod {
 }
 
 /// InstalledFlowImpl provides tokens for services that follow the "Installed" OAuth flow. (See
-/// https://www.oauth.com/oauth2-servers/authorization/,
-/// https://developers.google.com/identity/protocols/OAuth2InstalledApp).
+/// <https://www.oauth.com/oauth2-servers/authorization/>,
+/// <https://developers.google.com/identity/protocols/OAuth2InstalledApp>).
 pub struct InstalledFlow {
     pub(crate) app_secret: ApplicationSecret,
     pub(crate) method: InstalledFlowReturnMethod,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 //! ```test_harness,no_run
 //! use yup_oauth2::{InstalledFlowAuthenticator, InstalledFlowReturnMethod};
 //!
+//! # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 //! #[tokio::main]
 //! async fn main() {
 //!     // Read application secret from a file. Sometimes it's easier to compile it directly into

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,8 @@
 //! ```
 //!
 #![deny(missing_docs)]
+#![cfg_attr(yup_oauth2_docsrs, feature(doc_cfg))]
+
 pub mod authenticator;
 pub mod authenticator_delegate;
 mod device;

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -211,9 +211,7 @@ impl ServiceAccountFlow {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
-    use crate::authenticator::HyperClientBuilder;
     use crate::helper::read_service_account_key;
 
     // Valid but deactivated key.
@@ -222,13 +220,13 @@ mod tests {
     // Uncomment this test to verify that we can successfully obtain tokens.
     //#[tokio::test]
     #[allow(dead_code)]
-    #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
     async fn test_service_account_e2e() {
         let key = read_service_account_key(TEST_PRIVATE_KEY_PATH)
             .await
             .unwrap();
         let acc = ServiceAccountFlow::new(ServiceAccountFlowOpts { key, subject: None }).unwrap();
-        let client = crate::authenticator::DefaultHyperClient.build_hyper_client();
+        let client =
+            hyper::Client::builder().build(hyper_rustls::HttpsConnector::with_native_roots());
         println!(
             "{:?}",
             acc.token(&client, &["https://www.googleapis.com/auth/pubsub"])

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -1,7 +1,8 @@
-//! This module provides a token source (`GetToken`) that obtains tokens for service accounts.
+//! This module provides a flow that obtains tokens for service accounts.
+//!
 //! Service accounts are usually used by software (i.e., non-human actors) to get access to
-//! resources. Currently, this module only works with RS256 JWTs, which makes it at least suitable for
-//! authentication with Google services.
+//! resources. Currently, this module only works with RS256 JWTs, which makes it at least suitable
+//! for authentication with Google services.
 //!
 //! Resources:
 //! - [Using OAuth 2.0 for Server to Server
@@ -9,7 +10,6 @@
 //! - [JSON Web Tokens](https://jwt.io/)
 //!
 //! Copyright (c) 2016 Google Inc (lewinb@google.com).
-//!
 
 use crate::error::Error;
 use crate::types::TokenInfo;
@@ -54,8 +54,9 @@ fn decode_rsa_key(pem_pkcs8: &str) -> Result<PrivateKey, io::Error> {
     }
 }
 
-/// JSON schema of secret service account key. You can obtain the key from
-/// the Cloud Console at https://console.cloud.google.com/.
+/// JSON schema of secret service account key.
+///
+/// You can obtain the key from the [Cloud Console](https://console.cloud.google.com/).
 ///
 /// You can use `helpers::read_service_account_key()` as a quick way to read a JSON client
 /// secret into a ServiceAccountKey.
@@ -210,12 +211,10 @@ impl ServiceAccountFlow {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
+    use crate::authenticator::HyperClientBuilder;
     use crate::helper::read_service_account_key;
-    #[cfg(not(feature = "hyper-tls"))]
-    use hyper_rustls::HttpsConnector;
-    #[cfg(feature = "hyper-tls")]
-    use hyper_tls::HttpsConnector;
 
     // Valid but deactivated key.
     const TEST_PRIVATE_KEY_PATH: &'static str = "examples/Sanguine-69411a0c0eea.json";
@@ -223,18 +222,13 @@ mod tests {
     // Uncomment this test to verify that we can successfully obtain tokens.
     //#[tokio::test]
     #[allow(dead_code)]
+    #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
     async fn test_service_account_e2e() {
         let key = read_service_account_key(TEST_PRIVATE_KEY_PATH)
             .await
             .unwrap();
         let acc = ServiceAccountFlow::new(ServiceAccountFlowOpts { key, subject: None }).unwrap();
-        #[cfg(not(feature = "hyper-tls"))]
-        let https = HttpsConnector::with_native_roots();
-        #[cfg(feature = "hyper-tls")]
-        let https = HttpsConnector::new();
-        let client = hyper::Client::builder()
-            .pool_max_idle_per_host(0)
-            .build::<_, hyper::Body>(https);
+        let client = crate::authenticator::DefaultHyperClient.build_hyper_client();
         println!(
             "{:?}",
             acc.token(&client, &["https://www.googleapis.com/auth/pubsub"])


### PR DESCRIPTION
This adjusts the code and documentation for `--all-features` and
`--no-default-features` to work correctly. With `--no-default-features`
no `DefaultAuthenticator` is made available. Users are in control of
picking the `Connector` they want to use, and are not forced to stomach
a dependency on `rustls` or `hyper-tls` if their TLS implementation of
choice doesn't happen to match one of the two.

To indicate this, the unstable `doc_cfg` feature is used to build
documentation on docs.rs. That way the generated documentation has
notices on these types that look as such:

> This is supported on crate features hyper-rustls or hyper-tls only.

Additionally this functionality is tested via additional coverage in the
Actions' CI.

This, I believe, should be a backwards compatible change, with a very small
exception – users who have `RUSTDOCFLAGS='--cfg=yup_oauth2_docsrs'` set
and are building with a non-nightly compiler will observe failures to generate
documentation.