### PR TITLE
(GCP) Default Application Credentials flow/support (rebased and make tests pass)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ webbrowser = "0.5"
 hyper-rustls = "0.22.1"
 
 [workspace]
-members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/service_account", "examples/drive_example"]
+members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/service_account", "examples/drive_example", "examples/test-adc"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/test-adc/Cargo.toml
+++ b/examples/test-adc/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test-adc"
+version = "0.1.0"
+authors = ["Antti Peltonen <antti.peltonen@iki.fi>"]
+edition = "2018"
+
+[dependencies]
+yup-oauth2 = { path = "../../" }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/test-adc/Cargo.toml
+++ b/examples/test-adc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-adc"
 version = "0.1.0"
-authors = ["Antti Peltonen <antti.peltonen@iki.fi>"]
+authors = ["Antti Peltonen <antti.peltonen@iki.fi>", "Lukas Winkler <derwinlu@gmail.com>"]
 edition = "2018"
 
 [dependencies]

--- a/examples/test-adc/src/main.rs
+++ b/examples/test-adc/src/main.rs
@@ -1,12 +1,18 @@
+use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
 
 #[tokio::main]
 async fn main() {
-    let auth = ApplicationDefaultCredentialsAuthenticator::builder()
-        .await
-        .build()
-        .await
-        .unwrap();
+    let auth = match ApplicationDefaultCredentialsAuthenticator::builder().await {
+        ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth
+            .build()
+            .await
+            .expect("Unable to create instance metadata authenticator"),
+        ApplicationDefaultCredentialsTypes::ServiceAccount(auth) => auth
+            .build()
+            .await
+            .expect("Unable to create service account authenticator"),
+    };
     let scopes = &["https://www.googleapis.com/auth/pubsub"];
 
     let tok = auth.token(scopes).await.unwrap();

--- a/examples/test-adc/src/main.rs
+++ b/examples/test-adc/src/main.rs
@@ -1,0 +1,14 @@
+use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
+
+#[tokio::main]
+async fn main() {
+    let auth = ApplicationDefaultCredentialsAuthenticator::builder()
+        .await
+        .build()
+        .await
+        .unwrap();
+    let scopes = &["https://www.googleapis.com/auth/pubsub"];
+
+    let tok = auth.token(scopes).await.unwrap();
+    println!("token is: {:?}", tok);
+}

--- a/examples/test-adc/src/main.rs
+++ b/examples/test-adc/src/main.rs
@@ -1,9 +1,11 @@
 use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
+use yup_oauth2::ApplicationDefaultCredentialsFlowOpts;
 
 #[tokio::main]
 async fn main() {
-    let auth = match ApplicationDefaultCredentialsAuthenticator::builder().await {
+    let opts = ApplicationDefaultCredentialsFlowOpts::default();
+    let auth = match ApplicationDefaultCredentialsAuthenticator::builder(opts).await {
         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth
             .build()
             .await

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -32,7 +32,7 @@ impl ApplicationDefaultCredentialsFlow {
         C: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
     {
         let scope = crate::helper::join(scopes, ",");
-        let token_uri = format!("{}?scopes={}", self.metadata_url, scope); // TODO: This feels jank, can it be done better?
+        let token_uri = format!("{}?scopes={}", self.metadata_url, scope);
         let request = hyper::Request::get(token_uri)
             .header("Metadata-Flavor", "Google")
             .body(hyper::Body::from(String::new())) // why body is needed?

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -1,0 +1,36 @@
+use crate::error::Error;
+use crate::types::TokenInfo;
+
+pub struct ApplicationDefaultCredentialsFlowOpts;
+
+/// ServiceAccountFlow can fetch oauth tokens using a service account.
+pub struct ApplicationDefaultCredentialsFlow;
+impl ApplicationDefaultCredentialsFlow {
+    pub(crate) fn new(_opts: ApplicationDefaultCredentialsFlowOpts) -> Self {
+        ApplicationDefaultCredentialsFlow {}
+    }
+
+    pub(crate) async fn token<C, T>(
+        &self,
+        hyper_client: &hyper::Client<C>,
+        scopes: &[T],
+    ) -> Result<TokenInfo, Error>
+    where
+        T: AsRef<str>,
+        C: hyper::client::connect::Connect + Clone + Send + Sync + 'static,
+    {
+        let scope = crate::helper::join(scopes, ",");
+        let token_uri = format!("http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token?scopes={}", scope);
+        let request = hyper::Request::get(token_uri)
+            .header("Metadata-Flavor", "Google")
+            .body(hyper::Body::from(String::new())) // why body is needed?
+            .unwrap();
+        log::debug!("requesting token from metadata server: {:?}", request);
+        let (head, body) = hyper_client.request(request).await?.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
+        log::debug!("received response; head: {:?}, body: {:?}", head, body);
+        TokenInfo::from_json(&body)
+    }
+}
+
+// eof

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -278,9 +278,7 @@ impl ApplicationDefaultCredentialsAuthenticator {
     /// to provide tokens.
     pub fn from_instance_metadata(
     ) -> AuthenticatorBuilder<DefaultHyperClient, ApplicationDefaultCredentialsFlowOpts> {
-        AuthenticatorBuilder::<DefaultHyperClient, _>::with_auth_flow(
-            ApplicationDefaultCredentialsFlowOpts {},
-        )
+        AuthenticatorBuilder::new(ApplicationDefaultCredentialsFlowOpts {}, DefaultHyperClient)
     }
 
     /// Use modified builder pattern to create an Authenticator that pulls default application credentials
@@ -292,12 +290,14 @@ impl ApplicationDefaultCredentialsAuthenticator {
             crate::read_service_account_key(std::env::var("GOOGLE_APPLICATION_CREDENTIALS")?)
                 .await
                 .unwrap();
-        Ok(
-            AuthenticatorBuilder::<DefaultHyperClient, _>::with_auth_flow(ServiceAccountFlowOpts {
+
+        Ok(AuthenticatorBuilder::new(
+            ServiceAccountFlowOpts {
                 key: service_account_key,
                 subject: None,
-            }),
-        )
+            },
+            DefaultHyperClient,
+        ))
     }
 
     /// Use the builder pattern to deduce which model of authenticator should be used:

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -260,35 +260,65 @@ impl ServiceAccountAuthenticator {
 /// Create an authenticator that uses a application default credentials.
 /// ```
 /// # async fn foo() {
-///     let authenticator = yup_oauth2::ApplicationDefaultCredentialsAuthenticator::builder()
-///         .await
-///         .build()
-///         .await
-///         .expect("failed to create authenticator");
+///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder().await {
+///         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth
+///             .build()
+///             .await
+///             .expect("Unable to create instance metadata authenticator"),
+///         ApplicationDefaultCredentialsTypes::ServiceAccount(auth) => auth
+///             .build()
+///             .await
+///             .expect("Unable to create service account authenticator"),
+///     };
 /// # }
 /// ```
 pub struct ApplicationDefaultCredentialsAuthenticator;
 impl ApplicationDefaultCredentialsAuthenticator {
-    /// Use the builder pattern to create an Authenticator that uses a service account.
-    pub async fn builder(
+    /// Use modified builder pattern to create an Authenticator that uses GCE instance metadata server
+    /// to provide tokens.
+    pub fn from_instance_metadata(
     ) -> AuthenticatorBuilder<DefaultHyperClient, ApplicationDefaultCredentialsFlowOpts> {
-        match std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
-            Ok(_path) => {
-                todo!()
-                // # here we would need to do something like this:
-                // let service_account_key = crate::read_service_account_key(path).await.unwrap();
-                // AuthenticatorBuilder::<DefaultHyperClient, _>::with_auth_flow(
-                //     ServiceAccountFlowOpts {
-                //         key: service_account_key,
-                //         subject: None,
-                //     },
-                // )
-            }
-            Err(_e) => AuthenticatorBuilder::<DefaultHyperClient, _>::with_auth_flow(
-                ApplicationDefaultCredentialsFlowOpts {},
+        AuthenticatorBuilder::<DefaultHyperClient, _>::with_auth_flow(
+            ApplicationDefaultCredentialsFlowOpts {},
+        )
+    }
+
+    /// Use modified builder pattern to create an Authenticator that pulls default application credentials
+    /// service account file name from os environment variable.
+    pub async fn from_environment(
+    ) -> Result<AuthenticatorBuilder<DefaultHyperClient, ServiceAccountFlowOpts>, std::env::VarError>
+    {
+        let service_account_key =
+            crate::read_service_account_key(std::env::var("GOOGLE_APPLICATION_CREDENTIALS")?)
+                .await
+                .unwrap();
+        Ok(
+            AuthenticatorBuilder::<DefaultHyperClient, _>::with_auth_flow(ServiceAccountFlowOpts {
+                key: service_account_key,
+                subject: None,
+            }),
+        )
+    }
+
+    /// Use the builder pattern to deduce which model of authenticator should be used:
+    /// Service account one or GCE instance metadata kind
+    pub async fn builder() -> ApplicationDefaultCredentialsTypes {
+        match ApplicationDefaultCredentialsAuthenticator::from_environment().await {
+            Ok(builder) => ApplicationDefaultCredentialsTypes::ServiceAccount(builder),
+            Err(_) => ApplicationDefaultCredentialsTypes::InstanceMetadata(
+                ApplicationDefaultCredentialsAuthenticator::from_instance_metadata(),
             ),
         }
     }
+}
+/// Types of authenticators provided by ApplicationDefaultCredentialsAuthenticator
+pub enum ApplicationDefaultCredentialsTypes {
+    /// Service account based authenticator signature
+    ServiceAccount(AuthenticatorBuilder<DefaultHyperClient, ServiceAccountFlowOpts>),
+    /// GCE Instance Metadata based authenticator signature
+    InstanceMetadata(
+        AuthenticatorBuilder<DefaultHyperClient, ApplicationDefaultCredentialsFlowOpts>,
+    ),
 }
 
 /// ## Methods available when building any Authenticator.

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -257,7 +257,6 @@ impl ServiceAccountAuthenticator {
     }
 }
 
-// TODO: Can those use statements be cleaned up?
 /// Create an authenticator that uses a application default credentials.
 /// ```
 /// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -260,10 +260,11 @@ impl ServiceAccountAuthenticator {
 // TODO: Can those use statements be cleaned up?
 /// Create an authenticator that uses a application default credentials.
 /// ```
+/// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
-///     use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
-///     use yup_oauth2::ApplicationDefaultCredentialsFlowOpts;
-///     use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
+/// #    use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
+/// #    use yup_oauth2::ApplicationDefaultCredentialsFlowOpts;
+/// #    use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 ///
 ///     let opts = ApplicationDefaultCredentialsFlowOpts::default();
 ///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder(opts).await {
@@ -295,6 +296,11 @@ impl ApplicationDefaultCredentialsAuthenticator {
 
     /// Use the builder pattern to deduce which model of authenticator should be used:
     /// Service account one or GCE instance metadata kind
+    #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
+    #[cfg_attr(
+        yup_oauth2_docsrs,
+        doc(cfg(any(feature = "hyper-rustls", feature = "hyper-tls")))
+    )]
     pub async fn builder(
         opts: ApplicationDefaultCredentialsFlowOpts,
     ) -> ApplicationDefaultCredentialsTypes<DefaultHyperClient> {

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -257,10 +257,16 @@ impl ServiceAccountAuthenticator {
     }
 }
 
+// TODO: Can those use statements be cleaned up?
 /// Create an authenticator that uses a application default credentials.
 /// ```
 /// # async fn foo() {
-///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder().await {
+///     use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
+///     use yup_oauth2::ApplicationDefaultCredentialsFlowOpts;
+///     use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
+///
+///     let opts = ApplicationDefaultCredentialsFlowOpts::default();
+///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder(opts).await {
 ///         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth
 ///             .build()
 ///             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::authenticator::{
 pub use crate::helper::*;
 pub use crate::installed::InstalledFlowReturnMethod;
 
+pub use crate::application_default_credentials::ApplicationDefaultCredentialsFlowOpts;
 pub use crate::service_account::ServiceAccountKey;
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@
 #![deny(missing_docs)]
 #![cfg_attr(yup_oauth2_docsrs, feature(doc_cfg))]
 
+mod application_default_credentials;
 pub mod authenticator;
 pub mod authenticator_delegate;
 mod device;
@@ -89,7 +90,8 @@ mod types;
 
 #[doc(inline)]
 pub use crate::authenticator::{
-    DeviceFlowAuthenticator, InstalledFlowAuthenticator, ServiceAccountAuthenticator,
+    ApplicationDefaultCredentialsAuthenticator, DeviceFlowAuthenticator,
+    InstalledFlowAuthenticator, ServiceAccountAuthenticator,
 };
 
 pub use crate::helper::*;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -604,7 +604,6 @@ async fn test_default_application_credentials_from_metadata_server() {
     let _ = env_logger::try_init();
     let server = Server::run();
     server.expect(
-        // TODO: this does not work.
         Expectation::matching(all_of![
             request::method_path("GET", "/token"),
             request::query(url_decoded(all_of![contains((

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,9 +2,9 @@ use yup_oauth2::{
     authenticator::{DefaultAuthenticator, DefaultHyperClient, HyperClientBuilder},
     authenticator_delegate::{DeviceAuthResponse, DeviceFlowDelegate, InstalledFlowDelegate},
     error::{AuthError, AuthErrorCode},
-    ApplicationDefaultCredentialsAuthenticator, ApplicationSecret, DeviceFlowAuthenticator, Error,
-    InstalledFlowAuthenticator, InstalledFlowReturnMethod, ServiceAccountAuthenticator,
-    ServiceAccountKey,
+    ApplicationDefaultCredentialsAuthenticator, ApplicationDefaultCredentialsFlowOpts,
+    ApplicationSecret, DeviceFlowAuthenticator, Error, InstalledFlowAuthenticator,
+    InstalledFlowReturnMethod, ServiceAccountAuthenticator, ServiceAccountKey,
 };
 
 use std::future::Future;
@@ -619,7 +619,11 @@ async fn test_default_application_credentials_from_metadata_server() {
             "expires_in": 12345678,
         }))),
     );
-    let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder().await {
+
+    let opts = ApplicationDefaultCredentialsFlowOpts {
+        metadata_url: Some(server.url("/token").to_string()),
+    };
+    let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder(opts).await {
         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await.unwrap(),
         _ => panic!("We are not testing service account adc model"),
     };
@@ -627,5 +631,5 @@ async fn test_default_application_credentials_from_metadata_server() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_ne!(token.as_str(), "accesstoken");
+    assert_eq!(token.as_str(), "accesstoken");
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -599,7 +599,8 @@ async fn test_disk_storage() {
 }
 
 #[tokio::test]
-async fn test_default_application_credentials() {
+async fn test_default_application_credentials_from_metadata_server() {
+    use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
     let _ = env_logger::try_init();
     let server = Server::run();
     server.expect(
@@ -618,11 +619,10 @@ async fn test_default_application_credentials() {
             "expires_in": 12345678,
         }))),
     );
-    let authenticator = ApplicationDefaultCredentialsAuthenticator::builder()
-        .await
-        .build()
-        .await
-        .unwrap();
+    let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder().await {
+        ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await.unwrap(),
+        _ => panic!("We are not testing service account adc model"),
+    };
     let token = authenticator
         .token(&["https://googleapis.com/some/scope"])
         .await


### PR DESCRIPTION
This pull requests follows up on the work done by @braincow in #156.

It is rebased ontop of the current master, extends the structure to be inline with the new `with_client` functionality and fixes the test that was failing by allowing to provide a custom metadata url to the test server.

Please keep in mind this is my first rust based pull request and I am happy for feedback.

There are still 2 TODO's in the diff which I kind of find improvable.