### PR TITLE
feat(Authenticator client): Support custom connectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 time = { version = "0.3.7", features = ["local-offset", "serde"] }
 tokio = { version = "1.0", features = ["fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
+tower-service = "^0.3.1"
 url = "2"
 
 [dev-dependencies]


### PR DESCRIPTION
Update Authenticator to accept clients with custom connectors, rather
than depending on the sealed hyper::client::connect::Connect trait, as recommended by hyper: https://docs.rs/hyper/0.13.8/src/hyper/client/connect/mod.rs.html#256-258

The new types are more verbose, but seems to be the best we can do: https://github.com/hyperium/hyper/issues/2051#issuecomment-564419468

Closes #177.