### PR TITLE
feat(hyper-rustls): default hyper client support https and http

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -792,7 +792,7 @@ impl HyperClientBuilder for DefaultHyperClient {
         #[cfg(feature = "hyper-rustls")]
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
-            .https_only()
+            .https_or_http()
             .enable_http1()
             .enable_http2()
             .build();


### PR DESCRIPTION
Support http requests for the metadata server requests

Author: Pierre Seguin <pierre@orohealth.me>
Resolves: https://github.com/dermesser/yup-oauth2/issues/179