### PR TITLE
Implement service account impersonation.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rustls-pemfile = { version = "0.3", optional = true }
 seahash = "4"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-time = { version = "0.3.7", features = ["local-offset", "serde"] }
+time = { version = "0.3.7", features = ["local-offset", "parsing", "serde"] }
 tokio = { version = "1.0", features = ["fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
 tower-service = "^0.3.1"
 url = "2"

--- a/examples/service_account_impersonation.rs
+++ b/examples/service_account_impersonation.rs
@@ -1,0 +1,23 @@
+use yup_oauth2::{read_authorized_user_secret, ServiceAccountImpersonationAuthenticator};
+
+#[tokio::main]
+async fn main() {
+    let svc_email = std::env::args().skip(1).next().unwrap();
+    let home = std::env::var("HOME").unwrap();
+
+    let user_secret =
+        read_authorized_user_secret(format!("{}/.config/gcloud/application_default_credentials.json", home))
+            .await
+            .expect("user secret");
+
+    let auth = ServiceAccountImpersonationAuthenticator::builder(user_secret, &svc_email)
+        .build()
+        .await
+        .expect("authenticator");
+
+    let scopes = &["https://www.googleapis.com/auth/youtube.readonly"];
+    match auth.token(scopes).await {
+        Err(e) => println!("error: {:?}", e),
+        Ok(t) => println!("token: {:?}", t),
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,6 +154,8 @@ pub enum Error {
     UserError(String),
     /// A lower level IO error.
     LowLevelError(io::Error),
+    /// We required an access token, but received a response that didn't contain one.
+    MissingAccessToken,
     /// Other errors produced by a storage provider
     OtherError(anyhow::Error),
 }
@@ -206,6 +208,13 @@ impl fmt::Display for Error {
             }
             Error::UserError(ref s) => s.fmt(f),
             Error::LowLevelError(ref e) => e.fmt(f),
+            Error::MissingAccessToken => {
+                write!(
+                    f,
+                    "Expected an access token, but received a response without one"
+                )?;
+                Ok(())
+            }
             Error::OtherError(ref e) => e.fmt(f),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,16 +72,17 @@
 #![deny(missing_docs)]
 #![cfg_attr(yup_oauth2_docsrs, feature(doc_cfg))]
 
+pub mod access_token;
 mod application_default_credentials;
 pub mod authenticator;
 pub mod authenticator_delegate;
 pub mod authorized_user;
-pub mod access_token;
 mod device;
 pub mod error;
 mod helper;
 mod installed;
 mod refresh;
+pub mod service_account_impersonator;
 
 #[cfg(feature = "service_account")]
 mod service_account;
@@ -97,9 +98,9 @@ mod types;
 pub use crate::authenticator::ServiceAccountAuthenticator;
 #[doc(inline)]
 pub use crate::authenticator::{
-    ApplicationDefaultCredentialsAuthenticator, AuthorizedUserAuthenticator,
-    DeviceFlowAuthenticator, InstalledFlowAuthenticator,
-    AccessTokenAuthenticator,
+    AccessTokenAuthenticator, ApplicationDefaultCredentialsAuthenticator,
+    AuthorizedUserAuthenticator, DeviceFlowAuthenticator, InstalledFlowAuthenticator,
+    ServiceAccountImpersonationAuthenticator,
 };
 
 pub use crate::helper::*;

--- a/src/service_account_impersonator.rs
+++ b/src/service_account_impersonator.rs
@@ -1,0 +1,127 @@
+//! This module provides an authenticator that uses authorized user secrets
+//! to generate impersonated service account tokens.
+//!
+//! Resources:
+//! - [service account impersonation](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-oauth)
+
+use http::{header, Uri};
+use hyper::client::connect::Connection;
+use serde::Serialize;
+use std::error::Error as StdError;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tower_service::Service;
+
+use crate::{
+    authorized_user::{AuthorizedUserFlow, AuthorizedUserSecret},
+    storage::TokenInfo,
+    Error,
+};
+
+const IAM_CREDENTIALS_ENDPOINT: &'static str = "https://iamcredentials.googleapis.com";
+
+fn uri(email: &str) -> String {
+    format!(
+        "{}/v1/projects/-/serviceAccounts/{}:generateAccessToken",
+        IAM_CREDENTIALS_ENDPOINT, email
+    )
+}
+
+#[derive(Serialize)]
+struct Request<'a> {
+    scope: &'a [&'a str],
+    lifetime: &'a str,
+}
+
+// The impersonation response is in a different format from the other GCP
+// responses. Why, Google, why? The response to our impersonation request.
+// (Note that the naming is different from `types::AccessToken` even though
+// the data is equivalent.)
+#[derive(serde::Deserialize, Debug)]
+struct TokenResponse {
+    /// The actual token
+    #[serde(rename = "accessToken")]
+    access_token: String,
+    /// The time until the token expires and a new one needs to be requested.
+    /// In RFC3339 format.
+    #[serde(rename = "expireTime")]
+    expires_time: String,
+}
+
+impl From<TokenResponse> for TokenInfo {
+    fn from(resp: TokenResponse) -> TokenInfo {
+        let expires_at = time::OffsetDateTime::parse(
+            &resp.expires_time,
+            &time::format_description::well_known::Rfc3339,
+        )
+        .ok();
+        TokenInfo {
+            access_token: resp.access_token,
+            refresh_token: None,
+            expires_at,
+            id_token: None,
+        }
+    }
+}
+
+/// ServiceAccountImpersonationFlow uses user credentials to impersonate a service
+/// account.
+pub struct ServiceAccountImpersonationFlow {
+    pub(crate) inner_flow: AuthorizedUserFlow,
+    pub(crate) service_account_email: String,
+}
+
+impl ServiceAccountImpersonationFlow {
+    pub(crate) fn new(
+        user_secret: AuthorizedUserSecret,
+        service_account_email: &str,
+    ) -> ServiceAccountImpersonationFlow {
+        ServiceAccountImpersonationFlow {
+            inner_flow: AuthorizedUserFlow {
+                secret: user_secret,
+            },
+            service_account_email: service_account_email.to_string(),
+        }
+    }
+
+    pub(crate) async fn token<S, T>(
+        &self,
+        hyper_client: &hyper::Client<S>,
+        scopes: &[T],
+    ) -> Result<TokenInfo, Error>
+    where
+        T: AsRef<str>,
+        S: Service<Uri> + Clone + Send + Sync + 'static,
+        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
+        S::Future: Send + Unpin + 'static,
+        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    {
+        let inner_token = self
+            .inner_flow
+            .token(hyper_client, scopes)
+            .await?
+            .access_token;
+
+        let scopes: Vec<_> = scopes.iter().map(|s| s.as_ref()).collect();
+        let req_body = Request {
+            scope: &scopes,
+            // Max validity is 1h.
+            lifetime: "3600s",
+        };
+        let req_body = serde_json::to_vec(&req_body)?;
+
+        let request = hyper::Request::post(uri(&self.service_account_email))
+            .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
+            .header(header::CONTENT_LENGTH, req_body.len())
+            .header(header::AUTHORIZATION, format!("Bearer {}", inner_token))
+            .body(req_body.into())
+            .unwrap();
+
+        log::debug!("requesting impersonated token {:?}", request);
+        let (head, body) = hyper_client.request(request).await?.into_parts();
+        let body = hyper::body::to_bytes(body).await?;
+        log::debug!("received response; head: {:?}, body: {:?}", head, body);
+
+        let response: TokenResponse = serde_json::from_slice(&body)?;
+        Ok(response.into())
+    }
+}

--- a/src/service_account_impersonator.rs
+++ b/src/service_account_impersonator.rs
@@ -55,7 +55,7 @@ impl From<TokenResponse> for TokenInfo {
         )
         .ok();
         TokenInfo {
-            access_token: resp.access_token,
+            access_token: Some(resp.access_token),
             refresh_token: None,
             expires_at,
             id_token: None,
@@ -99,7 +99,8 @@ impl ServiceAccountImpersonationFlow {
             .inner_flow
             .token(hyper_client, scopes)
             .await?
-            .access_token;
+            .access_token
+            .ok_or(Error::MissingAccessToken)?;
 
         let scopes: Vec<_> = scopes.iter().map(|s| s.as_ref()).collect();
         let req_body = Request {


### PR DESCRIPTION
This implements support for using user credentials to impersonate a service account.

I had a bit of trouble figuring out what to put as the "inner" authenticator, because in principle I think you can do service account impersonation starting from other kinds of authentication. This suggests possibly having
```
pub struct ServiceAccountImpersonationFlow {
  inner: Authenticator<S>,
  service_account_email: String,
}
```
but then it isn't clear what to put for `S`. I thought about using `AuthFlow` instead, but it's private to `authenticator` and I didn't want to start on reorganization without asking first. And since I've only ever tested the user credentials route, I decided to just start there.