### PR TITLE
Add support for generating impersonated ids.

### DIFF
--- a/examples/service_account_impersonation.rs
+++ b/examples/service_account_impersonation.rs
@@ -12,6 +12,19 @@ async fn main() {
     .await
     .expect("user secret");
 
+    let auth = ServiceAccountImpersonationAuthenticator::builder(user_secret.clone(), &svc_email)
+        .build()
+        .await
+        .expect("authenticator");
+
+    let scopes = &["https://www.googleapis.com/auth/youtube.readonly"];
+    match auth.token(scopes).await {
+        Err(e) => println!("error: {:?}", e),
+        Ok(t) => println!("token: {:?}", t),
+    }
+
+    // If you configure the authenticator to request id tokens, it will give back id tokens
+    // instead of access tokens.
     let auth = ServiceAccountImpersonationAuthenticator::builder(user_secret, &svc_email)
         .request_id_token()
         .build()

--- a/examples/service_account_impersonation.rs
+++ b/examples/service_account_impersonation.rs
@@ -5,18 +5,21 @@ async fn main() {
     let svc_email = std::env::args().skip(1).next().unwrap();
     let home = std::env::var("HOME").unwrap();
 
-    let user_secret =
-        read_authorized_user_secret(format!("{}/.config/gcloud/application_default_credentials.json", home))
-            .await
-            .expect("user secret");
+    let user_secret = read_authorized_user_secret(format!(
+        "{}/.config/gcloud/application_default_credentials.json",
+        home
+    ))
+    .await
+    .expect("user secret");
 
     let auth = ServiceAccountImpersonationAuthenticator::builder(user_secret, &svc_email)
+        .request_id_token()
         .build()
         .await
         .expect("authenticator");
 
     let scopes = &["https://www.googleapis.com/auth/youtube.readonly"];
-    match auth.token(scopes).await {
+    match auth.id_token(scopes).await {
         Err(e) => println!("error: {:?}", e),
         Ok(t) => println!("token: {:?}", t),
     }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -81,7 +81,10 @@ where
 
     /// Return a token for the provided scopes, but don't reuse cached tokens. Instead,
     /// always fetch a new token from the OAuth server.
-    pub async fn force_refreshed_token<'a, T>(&'a self, scopes: &'a [T]) -> Result<AccessToken, Error>
+    pub async fn force_refreshed_token<'a, T>(
+        &'a self,
+        scopes: &'a [T],
+    ) -> Result<AccessToken, Error>
     where
         T: AsRef<str>,
     {
@@ -767,6 +770,15 @@ impl<C> AuthenticatorBuilder<C, ServiceAccountImpersonationFlow> {
             AuthFlow::ServiceAccountImpersonationFlow(self.auth_flow),
         )
         .await
+    }
+
+    /// Configure this authenticator to impersonate an ID token (rather an an access token,
+    /// as is the default).
+    ///
+    /// For more on impersonating ID tokens, see [google's docs](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-oidc).
+    pub fn request_id_token(mut self) -> Self {
+        self.auth_flow.access_token = false;
+        self
     }
 }
 


### PR DESCRIPTION
The previous service account impersonation feature only allowed requesting impersonated access tokens. This one adds id tokens.