### PR TITLE
Add user authentication to the ADC flow.

### DIFF
--- a/examples/test-adc/src/main.rs
+++ b/examples/test-adc/src/main.rs
@@ -1,20 +1,14 @@
-use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 use yup_oauth2::ApplicationDefaultCredentialsAuthenticator;
-use yup_oauth2::ApplicationDefaultCredentialsFlowOpts;
+use yup_oauth2::InstanceMetadataFlowOpts;
 
 #[tokio::main]
 async fn main() {
-    let opts = ApplicationDefaultCredentialsFlowOpts::default();
-    let auth = match ApplicationDefaultCredentialsAuthenticator::builder(opts).await {
-        ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth
-            .build()
-            .await
-            .expect("Unable to create instance metadata authenticator"),
-        ApplicationDefaultCredentialsTypes::ServiceAccount(auth) => auth
-            .build()
-            .await
-            .expect("Unable to create service account authenticator"),
-    };
+    let opts = InstanceMetadataFlowOpts::default();
+    let auth = ApplicationDefaultCredentialsAuthenticator::builder(opts)
+        .await
+        .build()
+        .await
+        .expect("Unable to create authenticator");
     let scopes = &["https://www.googleapis.com/auth/pubsub"];
 
     let tok = auth.token(scopes).await.unwrap();

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -1,26 +1,26 @@
 use crate::error::Error;
 use crate::types::TokenInfo;
+use http::Uri;
 use hyper::client::connect::Connection;
 use std::error::Error as StdError;
-use http::Uri;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
-/// Provide options for the Application Default Credential Flow, mostly used for testing
+/// Provide options for the Instance Metadata Flow, mostly used for testing
 #[derive(Default, Clone, Debug)]
-pub struct ApplicationDefaultCredentialsFlowOpts {
+pub struct InstanceMetadataFlowOpts {
     /// Used as base to build the url during token request from GCP metadata server
     pub metadata_url: Option<String>,
 }
 
-pub struct ApplicationDefaultCredentialsFlow {
+pub struct InstanceMetadataFlow {
     metadata_url: String,
 }
 
-impl ApplicationDefaultCredentialsFlow {
-    pub(crate) fn new(opts: ApplicationDefaultCredentialsFlowOpts) -> Self {
+impl InstanceMetadataFlow {
+    pub(crate) fn new(opts: InstanceMetadataFlowOpts) -> Self {
         let metadata_url = opts.metadata_url.unwrap_or_else(|| "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token".to_string());
-        ApplicationDefaultCredentialsFlow { metadata_url }
+        InstanceMetadataFlow { metadata_url }
     }
 
     pub(crate) async fn token<S, T>(

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -306,10 +306,11 @@ impl ServiceAccountAuthenticator {
 /// #    use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 ///
 ///     let opts = ApplicationDefaultCredentialsFlowOpts::default();
-///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder(opts)
+///     let authenticator = ApplicationDefaultCredentialsAuthenticator::builder(opts)
 ///        .await
 ///        .build()
-///        .await?;
+///        .await
+///        .expect("failed to build application default credentials authenticator");
 /// # }
 /// ```
 pub struct ApplicationDefaultCredentialsAuthenticator;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -306,16 +306,10 @@ impl ServiceAccountAuthenticator {
 /// #    use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
 ///
 ///     let opts = ApplicationDefaultCredentialsFlowOpts::default();
-///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder(opts).await {
-///         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth
-///             .build()
-///             .await
-///             .expect("Unable to create instance metadata authenticator"),
-///         ApplicationDefaultCredentialsTypes::ServiceAccount(auth) => auth
-///             .build()
-///             .await
-///             .expect("Unable to create service account authenticator"),
-///     };
+///     let authenticator = match ApplicationDefaultCredentialsAuthenticator::builder(opts)
+///        .await
+///        .build()
+///        .await?;
 /// # }
 /// ```
 pub struct ApplicationDefaultCredentialsAuthenticator;
@@ -414,6 +408,7 @@ where
     pub async fn build(self) -> Result<Authenticator<C::Connector>, Error> {
         match self {
             ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => Ok(auth.build().await?),
+            #[cfg(feature = "service_account")]
             ApplicationDefaultCredentialsTypes::ServiceAccount(auth) => Ok(auth.build().await?),
             ApplicationDefaultCredentialsTypes::AuthorizedUser(auth) => Ok(auth.build().await?),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,6 +156,8 @@ pub enum Error {
     LowLevelError(io::Error),
     /// We required an access token, but received a response that didn't contain one.
     MissingAccessToken,
+    /// We tried to read an environment variable, but failed.
+    EnvError(std::env::VarError),
     /// Other errors produced by a storage provider
     OtherError(anyhow::Error),
 }
@@ -175,6 +177,12 @@ impl From<AuthError> for Error {
 impl From<serde_json::Error> for Error {
     fn from(value: serde_json::Error) -> Error {
         Error::JSONError(value)
+    }
+}
+
+impl From<std::env::VarError> for Error {
+    fn from(value: std::env::VarError) -> Error {
+        Error::EnvError(value)
     }
 }
 
@@ -207,6 +215,7 @@ impl fmt::Display for Error {
                 Ok(())
             }
             Error::UserError(ref s) => s.fmt(f),
+            Error::EnvError(ref e) => e.fmt(f),
             Error::LowLevelError(ref e) => e.fmt(f),
             Error::MissingAccessToken => {
                 write!(
@@ -227,6 +236,7 @@ impl StdError for Error {
             Error::AuthError(ref err) => Some(err),
             Error::JSONError(ref err) => Some(err),
             Error::LowLevelError(ref err) => Some(err),
+            Error::EnvError(ref err) => Some(err),
             _ => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,13 +100,13 @@ pub use crate::authenticator::ServiceAccountAuthenticator;
 pub use crate::authenticator::{
     AccessTokenAuthenticator, ApplicationDefaultCredentialsAuthenticator,
     AuthorizedUserAuthenticator, DeviceFlowAuthenticator, InstalledFlowAuthenticator,
-    ServiceAccountImpersonationAuthenticator,
+    InstanceMetadataAuthenticator, ServiceAccountImpersonationAuthenticator,
 };
 
 pub use crate::helper::*;
 pub use crate::installed::InstalledFlowReturnMethod;
 
-pub use crate::application_default_credentials::ApplicationDefaultCredentialsFlowOpts;
+pub use crate::application_default_credentials::InstanceMetadataFlowOpts;
 #[cfg(feature = "service_account")]
 pub use crate::service_account::ServiceAccountKey;
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,9 @@
 use yup_oauth2::{
     authenticator::{DefaultAuthenticator, DefaultHyperClient, HyperClientBuilder},
     authenticator_delegate::{DeviceAuthResponse, DeviceFlowDelegate, InstalledFlowDelegate},
-    ApplicationDefaultCredentialsAuthenticator, ApplicationDefaultCredentialsFlowOpts,
-    ApplicationSecret, DeviceFlowAuthenticator, InstalledFlowAuthenticator,
-    InstalledFlowReturnMethod, ServiceAccountAuthenticator, ServiceAccountKey,
-    AccessTokenAuthenticator,
+    AccessTokenAuthenticator, ApplicationSecret, DeviceFlowAuthenticator,
+    InstalledFlowAuthenticator, InstalledFlowReturnMethod, InstanceMetadataAuthenticator,
+    InstanceMetadataFlowOpts, ServiceAccountAuthenticator, ServiceAccountKey,
 };
 
 use std::future::Future;
@@ -93,7 +92,10 @@ async fn test_device_success() {
         .token(&["https://www.googleapis.com/scope/1"])
         .await
         .expect("token failed");
-    assert_eq!("accesstoken", token.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        token.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -215,7 +217,7 @@ async fn create_installed_flow_auth(
         }
     }
 
-    let client =  DefaultHyperClient.build_test_hyper_client();
+    let client = DefaultHyperClient.build_test_hyper_client();
     let mut builder = InstalledFlowAuthenticator::with_client(app_secret, method, client.clone())
         .flow_delegate(Box::new(FD(client)));
 
@@ -254,7 +256,10 @@ async fn test_installed_interactive_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -283,7 +288,10 @@ async fn test_installed_redirect_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -352,8 +360,13 @@ async fn test_service_account_success() {
         .token(&["https://www.googleapis.com/auth/pubsub"])
         .await
         .expect("token failed");
-    assert!(tok.token().expect("should have access token").contains("ya29.c.ElouBywiys0Ly"));
-    assert!(OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap());
+    assert!(tok
+        .token()
+        .expect("should have access token")
+        .contains("ya29.c.ElouBywiys0Ly"));
+    assert!(
+        OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap()
+    );
 }
 
 #[tokio::test]
@@ -403,7 +416,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 
     server.expect(
         Expectation::matching(all_of![
@@ -424,7 +440,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken2", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken2",
+        tok.token().expect("should have access token")
+    );
 
     server.expect(
         Expectation::matching(all_of![
@@ -445,7 +464,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken3", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken3",
+        tok.token().expect("should have access token")
+    );
 
     // Refresh fails, but renewing the token succeeds.
     // PR #165
@@ -477,9 +499,7 @@ async fn test_refresh() {
         }))),
     );
 
-    let tok_err = auth
-        .token(&["https://googleapis.com/some/scope"])
-        .await;
+    let tok_err = auth.token(&["https://googleapis.com/some/scope"]).await;
     assert!(tok_err.is_ok());
 }
 
@@ -515,7 +535,10 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        token1.token().expect("should have access token"),
+        "accesstoken"
+    );
     assert_eq!(token1, token2);
 
     // Create a new authenticator. This authenticator does not share a cache
@@ -541,7 +564,10 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token3.token().expect("should have access token"), "accesstoken2");
+    assert_eq!(
+        token3.token().expect("should have access token"),
+        "accesstoken2"
+    );
 }
 
 #[tokio::test]
@@ -583,7 +609,10 @@ async fn test_disk_storage() {
             .token(&["https://googleapis.com/some/scope"])
             .await
             .expect("failed to get token");
-        assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+        assert_eq!(
+            token1.token().expect("should have access token"),
+            "accesstoken"
+        );
         assert_eq!(token1, token2);
     }
 
@@ -605,13 +634,15 @@ async fn test_disk_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        token1.token().expect("should have access token"),
+        "accesstoken"
+    );
     assert_eq!(token1, token2);
 }
 
 #[tokio::test]
 async fn test_default_application_credentials_from_metadata_server() {
-    use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
     let _ = env_logger::try_init();
     let server = Server::run();
     server.expect(
@@ -630,29 +661,39 @@ async fn test_default_application_credentials_from_metadata_server() {
         }))),
     );
 
-    let opts = ApplicationDefaultCredentialsFlowOpts {
+    let opts = InstanceMetadataFlowOpts {
         metadata_url: Some(server.url("/token").to_string()),
     };
-    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(opts, DefaultHyperClient.build_test_hyper_client()).await {
-        ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await.unwrap(),
-        _ => panic!("We are not testing service account adc model"),
-    };
+    let authenticator = InstanceMetadataAuthenticator::with_client(
+        opts,
+        DefaultHyperClient.build_test_hyper_client(),
+    )
+    .build()
+    .await
+    .unwrap();
     let access_token = authenticator
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(access_token.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        access_token.token().expect("should have access token"),
+        "accesstoken"
+    );
 }
 
 #[tokio::test]
 async fn test_token() {
-    let authenticator = AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
-	.build()
-	.await
-	.unwrap();
+    let authenticator =
+        AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
+            .build()
+            .await
+            .unwrap();
     let access_token = authenticator
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(access_token.token().expect("should have access token"), "0815".to_string());
+    assert_eq!(
+        access_token.token().expect("should have access token"),
+        "0815".to_string()
+    );
 }


### PR DESCRIPTION
According to google's docs [1], the ADC strategy is

1. env variable
2. user credentials
3. metadata server

Currently, this crate does 1 and 3; this PR inserts 2 in there.

[1] https://cloud.google.com/docs/authentication/application-default-credentials

Note that this is a breaking change, and it also breaks the test for me locally because I have user credentials configured. Presumably the CI doesn't so I guess they'll succeed there? But this isn't great so I've marked it as a draft.