### PR TITLE
fix: re-export hyper and hyper-rustls dependencies (urgent!)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,8 @@ pub mod storage;
 mod types;
 
 pub use hyper;
+
+#[cfg(feature = "hyper-rustls")]
 pub use hyper_rustls;
 
 #[cfg(feature = "service_account")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod storage;
 
 mod types;
 
+pub use hyper;
 pub use hyper_rustls;
 
 #[cfg(feature = "service_account")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,8 @@ pub mod storage;
 
 mod types;
 
+pub use hyper_rustls;
+
 #[cfg(feature = "service_account")]
 #[doc(inline)]
 pub use crate::authenticator::ServiceAccountAuthenticator;


### PR DESCRIPTION
Hello, I am the maintainer of [fcm_v1](https://github.com/sanath-2024/fcm_v1) which uses `yup_oauth2` to perform authentication for Firebase Cloud Messaging. In order to construct an `Authenticator`, I need to specify certain generic parameters from `hyper` and `hyper-rustls`, as shown here:

https://github.com/sanath-2024/fcm_v1/blob/8bf3d4225f29f9faca1ce7f1c5cc456ce641d172/src/auth.rs#L3-L16

Recently, `yup-oauth2` did a minor version bump from 8.1 to 8.2, while the dependency on `hyper-rustls` performed a major version bump from 0.23 to 0.24. This has been causing compilation issues for some of my users, which may be avoided if `yup-oauth2` re-exports these two dependencies so that I can keep my dependencies for `hyper` and `hyper-rustls` compatible with `yup-oauth2`.