### PR TITLE
Apply rustfmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,18 @@ jobs:
           args: --all-features
         env:
           RUSTDOCFLAGS: --cfg yup_oauth2_docsrs
+
+  fmt:
+    name: yup-oauth2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          default: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: -- --check

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -7,8 +7,8 @@
 
 use std::error::Error as StdError;
 
-use hyper::client::connect::Connection;
 use http::Uri;
+use hyper::client::connect::Connection;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -7,8 +7,8 @@
 //! access token of the other service by generating a new token.
 use crate::error::Error;
 use crate::types::TokenInfo;
-use hyper::client::connect::Connection;
 use http::Uri;
+use hyper::client::connect::Connection;
 use std::error::Error as StdError;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
 use crate::types::TokenInfo;
+use http::Uri;
 use hyper::client::connect::Connection;
 use std::error::Error as StdError;
-use http::Uri;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -668,7 +668,7 @@ impl<C> AuthenticatorBuilder<C, InstalledFlow> {
         }
     }
     /// Force the user to select an account on the initial request
-    pub fn force_account_selection(self, force: bool)->Self{
+    pub fn force_account_selection(self, force: bool) -> Self {
         AuthenticatorBuilder {
             auth_flow: InstalledFlow {
                 force_account_selection: force,

--- a/src/authenticator_delegate.rs
+++ b/src/authenticator_delegate.rs
@@ -96,7 +96,7 @@ async fn present_user_code(device_auth_resp: &DeviceAuthResponse) {
     println!("Do not close this application until you either denied or granted access.");
     let printable_time = match UtcOffset::current_local_offset() {
         Ok(offset) => device_auth_resp.expires_at.to_offset(offset),
-        Err(_) => device_auth_resp.expires_at,  // Fallback to printing in UTC
+        Err(_) => device_auth_resp.expires_at, // Fallback to printing in UTC
     };
     println!("You have time until {}.", printable_time);
 }
@@ -162,5 +162,7 @@ impl InstalledFlowDelegate for DefaultInstalledFlowDelegate {}
 #[derive(Clone)]
 pub struct DefaultInstalledFlowDelegateWithRedirectURI(pub String);
 impl InstalledFlowDelegate for DefaultInstalledFlowDelegateWithRedirectURI {
-    fn redirect_uri(&self) -> Option<&str> { Some(self.0.as_str()) }
+    fn redirect_uri(&self) -> Option<&str> {
+        Some(self.0.as_str())
+    }
 }

--- a/src/authorized_user.rs
+++ b/src/authorized_user.rs
@@ -6,9 +6,9 @@
 //!
 use crate::error::Error;
 use crate::types::TokenInfo;
+use http::Uri;
 use hyper::client::connect::Connection;
 use hyper::header;
-use http::Uri;
 use serde::{Deserialize, Serialize};
 use std::error::Error as StdError;
 use tokio::io::{AsyncRead, AsyncWrite};

--- a/src/device.rs
+++ b/src/device.rs
@@ -8,12 +8,12 @@ use std::borrow::Cow;
 use std::error::Error as StdError;
 use std::time::Duration;
 
+use http::Uri;
 use hyper::client::connect::Connection;
 use hyper::header;
-use http::Uri;
-use url::form_urlencoded;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
+use url::form_urlencoded;
 
 pub const GOOGLE_DEVICE_CODE_URL: &str = "https://accounts.google.com/o/oauth2/device/code";
 

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -12,9 +12,9 @@ use std::error::Error as StdError;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use http::Uri;
 use hyper::client::connect::Connection;
 use hyper::header;
-use http::Uri;
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::oneshot;
@@ -62,9 +62,7 @@ where
     if force_account_selection {
         params.push("&prompt=select_account+consent".to_string());
     }
-    params
-    .into_iter()
-    .fold(url, |mut u, param| {
+    params.into_iter().fold(url, |mut u, param| {
         u.push_str(&percent_encode(param.as_ref(), &QUERY_SET).to_string());
         u
     })
@@ -114,7 +112,7 @@ impl InstalledFlow {
             app_secret,
             method,
             flow_delegate: Box::new(DefaultInstalledFlowDelegate),
-            force_account_selection: false
+            force_account_selection: false,
         }
     }
 
@@ -139,7 +137,7 @@ impl InstalledFlow {
         match self.method {
             InstalledFlowReturnMethod::HTTPRedirect => {
                 self.ask_auth_code_via_http(hyper_client, None, &self.app_secret, scopes)
-                .await
+                    .await
             }
             InstalledFlowReturnMethod::HTTPPortRedirect(port) => {
                 self.ask_auth_code_via_http(hyper_client, Some(port), &self.app_secret, scopes)
@@ -303,7 +301,7 @@ impl InstalledFlowServer {
         });
         let addr: std::net::SocketAddr = match port {
             Some(port) => ([127, 0, 0, 1], port).into(),
-            None => ([127, 0, 0, 1], 0).into()
+            None => ([127, 0, 0, 1], 0).into(),
         };
         let server = hyper::server::Server::try_bind(&addr)?;
         let server = server.http1_only(true).serve(service);

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::types::{ApplicationSecret, TokenInfo};
 
-use http::{Uri};
+use http::Uri;
 use hyper::client::connect::Connection;
 use hyper::header;
 use std::error::Error as StdError;

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -16,20 +16,20 @@
 use crate::error::Error;
 use crate::types::TokenInfo;
 
-use std::{io, path::PathBuf, error::Error as StdError};
+use std::{error::Error as StdError, io, path::PathBuf};
 
+use http::Uri;
 use hyper::client::connect::Connection;
 use hyper::header;
-use http::Uri;
 use rustls::{
     self,
     sign::{self, SigningKey},
     PrivateKey,
 };
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
-use time::OffsetDateTime;
 use url::form_urlencoded;
 
 const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:jwt-bearer";

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
 use yup_oauth2::{
     authenticator::{DefaultAuthenticator, DefaultHyperClient, HyperClientBuilder},
     authenticator_delegate::{DeviceAuthResponse, DeviceFlowDelegate, InstalledFlowDelegate},
-    ApplicationDefaultCredentialsAuthenticator, ApplicationDefaultCredentialsFlowOpts,
-    ApplicationSecret, DeviceFlowAuthenticator, InstalledFlowAuthenticator,
-    InstalledFlowReturnMethod, ServiceAccountAuthenticator, ServiceAccountKey,
-    AccessTokenAuthenticator,
+    AccessTokenAuthenticator, ApplicationDefaultCredentialsAuthenticator,
+    ApplicationDefaultCredentialsFlowOpts, ApplicationSecret, DeviceFlowAuthenticator,
+    InstalledFlowAuthenticator, InstalledFlowReturnMethod, ServiceAccountAuthenticator,
+    ServiceAccountKey,
 };
 
 use std::future::Future;
@@ -93,7 +93,10 @@ async fn test_device_success() {
         .token(&["https://www.googleapis.com/scope/1"])
         .await
         .expect("token failed");
-    assert_eq!("accesstoken", token.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        token.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -215,7 +218,7 @@ async fn create_installed_flow_auth(
         }
     }
 
-    let client =  DefaultHyperClient.build_test_hyper_client();
+    let client = DefaultHyperClient.build_test_hyper_client();
     let mut builder = InstalledFlowAuthenticator::with_client(app_secret, method, client.clone())
         .flow_delegate(Box::new(FD(client)));
 
@@ -254,7 +257,10 @@ async fn test_installed_interactive_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -283,7 +289,10 @@ async fn test_installed_redirect_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -352,8 +361,13 @@ async fn test_service_account_success() {
         .token(&["https://www.googleapis.com/auth/pubsub"])
         .await
         .expect("token failed");
-    assert!(tok.token().expect("should have access token").contains("ya29.c.ElouBywiys0Ly"));
-    assert!(OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap());
+    assert!(tok
+        .token()
+        .expect("should have access token")
+        .contains("ya29.c.ElouBywiys0Ly"));
+    assert!(
+        OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap()
+    );
 }
 
 #[tokio::test]
@@ -403,7 +417,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 
     server.expect(
         Expectation::matching(all_of![
@@ -424,7 +441,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken2", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken2",
+        tok.token().expect("should have access token")
+    );
 
     server.expect(
         Expectation::matching(all_of![
@@ -445,7 +465,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken3", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken3",
+        tok.token().expect("should have access token")
+    );
 
     // Refresh fails, but renewing the token succeeds.
     // PR #165
@@ -477,9 +500,7 @@ async fn test_refresh() {
         }))),
     );
 
-    let tok_err = auth
-        .token(&["https://googleapis.com/some/scope"])
-        .await;
+    let tok_err = auth.token(&["https://googleapis.com/some/scope"]).await;
     assert!(tok_err.is_ok());
 }
 
@@ -515,7 +536,10 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        token1.token().expect("should have access token"),
+        "accesstoken"
+    );
     assert_eq!(token1, token2);
 
     // Create a new authenticator. This authenticator does not share a cache
@@ -541,7 +565,10 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token3.token().expect("should have access token"), "accesstoken2");
+    assert_eq!(
+        token3.token().expect("should have access token"),
+        "accesstoken2"
+    );
 }
 
 #[tokio::test]
@@ -583,7 +610,10 @@ async fn test_disk_storage() {
             .token(&["https://googleapis.com/some/scope"])
             .await
             .expect("failed to get token");
-        assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+        assert_eq!(
+            token1.token().expect("should have access token"),
+            "accesstoken"
+        );
         assert_eq!(token1, token2);
     }
 
@@ -605,7 +635,10 @@ async fn test_disk_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        token1.token().expect("should have access token"),
+        "accesstoken"
+    );
     assert_eq!(token1, token2);
 }
 
@@ -633,7 +666,12 @@ async fn test_default_application_credentials_from_metadata_server() {
     let opts = ApplicationDefaultCredentialsFlowOpts {
         metadata_url: Some(server.url("/token").to_string()),
     };
-    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(opts, DefaultHyperClient.build_test_hyper_client()).await {
+    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(
+        opts,
+        DefaultHyperClient.build_test_hyper_client(),
+    )
+    .await
+    {
         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await.unwrap(),
         _ => panic!("We are not testing service account adc model"),
     };
@@ -641,18 +679,25 @@ async fn test_default_application_credentials_from_metadata_server() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(access_token.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        access_token.token().expect("should have access token"),
+        "accesstoken"
+    );
 }
 
 #[tokio::test]
 async fn test_token() {
-    let authenticator = AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
-	.build()
-	.await
-	.unwrap();
+    let authenticator =
+        AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
+            .build()
+            .await
+            .unwrap();
     let access_token = authenticator
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(access_token.token().expect("should have access token"), "0815".to_string());
+    assert_eq!(
+        access_token.token().expect("should have access token"),
+        "0815".to_string()
+    );
 }


### PR DESCRIPTION
I found that current code is not formatted by rustfmt although this repository contains `rustfmt.toml`.
This PR applies `cargo fmt` and enable format checking in CI.