### PR TITLE
Support id tokens from metadata service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "yup-oauth2"
-version = "8.3.0"
+version = "9.0.0"
 authors = ["Sebastian Thiel <byronimo@gmail.com>", "Lewin Bormann <lbo@spheniscida.de>"]
 repository = "https://github.com/dermesser/yup-oauth2"
 description = "An oauth2 implementation, providing the 'device', 'service account' and 'installed' authorization flows"

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -25,9 +25,9 @@ impl ApplicationDefaultCredentialsFlow {
         let id_token = opts.id_token;
         let metadata_url = opts.metadata_url
             .unwrap_or_else(|| if id_token {
-                 "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token".to_string()
-            } else {
                  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity".to_string()
+            } else {
+                 "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token".to_string()
             });
         ApplicationDefaultCredentialsFlow {
             metadata_url,

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -64,7 +64,16 @@ impl ApplicationDefaultCredentialsFlow {
         let (head, body) = hyper_client.request(request).await?.into_parts();
         let body = hyper::body::to_bytes(body).await?;
         log::debug!("received response; head: {:?}, body: {:?}", head, body);
-        TokenInfo::from_json(&body)
+        if self.id_token {
+            Ok(TokenInfo {
+                id_token: Some(String::from_utf8(body.to_vec())?),
+                access_token: None,
+                refresh_token: None,
+                expires_at: None,
+            })
+        } else {
+            TokenInfo::from_json(&body)
+        }
     }
 }
 

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -1,8 +1,8 @@
 use crate::error::Error;
 use crate::types::TokenInfo;
+use http::Uri;
 use hyper::client::connect::Connection;
 use std::error::Error as StdError;
-use http::Uri;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
@@ -11,16 +11,28 @@ use tower_service::Service;
 pub struct ApplicationDefaultCredentialsFlowOpts {
     /// Used as base to build the url during token request from GCP metadata server
     pub metadata_url: Option<String>,
+    /// If true, asks for an ID token instead of an OAuth access token.
+    pub id_token: bool,
 }
 
 pub struct ApplicationDefaultCredentialsFlow {
     metadata_url: String,
+    id_token: bool,
 }
 
 impl ApplicationDefaultCredentialsFlow {
     pub(crate) fn new(opts: ApplicationDefaultCredentialsFlowOpts) -> Self {
-        let metadata_url = opts.metadata_url.unwrap_or_else(|| "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token".to_string());
-        ApplicationDefaultCredentialsFlow { metadata_url }
+        let id_token = opts.id_token;
+        let metadata_url = opts.metadata_url
+            .unwrap_or_else(|| if id_token {
+                 "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token".to_string()
+            } else {
+                 "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity".to_string()
+            });
+        ApplicationDefaultCredentialsFlow {
+            metadata_url,
+            id_token,
+        }
     }
 
     pub(crate) async fn token<S, T>(
@@ -36,7 +48,14 @@ impl ApplicationDefaultCredentialsFlow {
         S::Error: Into<Box<dyn StdError + Send + Sync>>,
     {
         let scope = crate::helper::join(scopes, ",");
-        let token_uri = format!("{}?scopes={}", self.metadata_url, scope);
+        let token_uri = format!(
+            "{}?{}={}",
+            self.metadata_url,
+            // For ID tokens we use the scope arguments to pass the audience. Bit of a hack, since
+            // this was originally designed only for the access tokens.
+            if self.id_token { "audience" } else { "scopes" },
+            scope
+        );
         let request = hyper::Request::get(token_uri)
             .header("Metadata-Flavor", "Google")
             .body(hyper::Body::from(String::new())) // why body is needed?

--- a/src/error.rs
+++ b/src/error.rs
@@ -150,6 +150,8 @@ pub enum Error {
     AuthError(AuthError),
     /// Error while decoding a JSON response.
     JSONError(serde_json::Error),
+    /// Error while decoding a text response.
+    Utf8Error(std::string::FromUtf8Error),
     /// Error within user input.
     UserError(String),
     /// A lower level IO error.
@@ -158,6 +160,12 @@ pub enum Error {
     MissingAccessToken,
     /// Other errors produced by a storage provider
     OtherError(anyhow::Error),
+}
+
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(v: std::string::FromUtf8Error) -> Self {
+        Self::Utf8Error(v)
+    }
 }
 
 impl From<hyper::Error> for Error {
@@ -215,6 +223,7 @@ impl fmt::Display for Error {
                 )?;
                 Ok(())
             }
+            Error::Utf8Error(ref err) => err.fmt(f),
             Error::OtherError(ref e) => e.fmt(f),
         }
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
 use yup_oauth2::{
     authenticator::{DefaultAuthenticator, DefaultHyperClient, HyperClientBuilder},
     authenticator_delegate::{DeviceAuthResponse, DeviceFlowDelegate, InstalledFlowDelegate},
-    ApplicationDefaultCredentialsAuthenticator, ApplicationDefaultCredentialsFlowOpts,
-    ApplicationSecret, DeviceFlowAuthenticator, InstalledFlowAuthenticator,
-    InstalledFlowReturnMethod, ServiceAccountAuthenticator, ServiceAccountKey,
-    AccessTokenAuthenticator,
+    AccessTokenAuthenticator, ApplicationDefaultCredentialsAuthenticator,
+    ApplicationDefaultCredentialsFlowOpts, ApplicationSecret, DeviceFlowAuthenticator,
+    InstalledFlowAuthenticator, InstalledFlowReturnMethod, ServiceAccountAuthenticator,
+    ServiceAccountKey,
 };
 
 use std::future::Future;
@@ -93,7 +93,10 @@ async fn test_device_success() {
         .token(&["https://www.googleapis.com/scope/1"])
         .await
         .expect("token failed");
-    assert_eq!("accesstoken", token.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        token.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -215,7 +218,7 @@ async fn create_installed_flow_auth(
         }
     }
 
-    let client =  DefaultHyperClient.build_test_hyper_client();
+    let client = DefaultHyperClient.build_test_hyper_client();
     let mut builder = InstalledFlowAuthenticator::with_client(app_secret, method, client.clone())
         .flow_delegate(Box::new(FD(client)));
 
@@ -254,7 +257,10 @@ async fn test_installed_interactive_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -283,7 +289,10 @@ async fn test_installed_redirect_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 }
 
 #[tokio::test]
@@ -352,8 +361,13 @@ async fn test_service_account_success() {
         .token(&["https://www.googleapis.com/auth/pubsub"])
         .await
         .expect("token failed");
-    assert!(tok.token().expect("should have access token").contains("ya29.c.ElouBywiys0Ly"));
-    assert!(OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap());
+    assert!(tok
+        .token()
+        .expect("should have access token")
+        .contains("ya29.c.ElouBywiys0Ly"));
+    assert!(
+        OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap()
+    );
 }
 
 #[tokio::test]
@@ -403,7 +417,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken",
+        tok.token().expect("should have access token")
+    );
 
     server.expect(
         Expectation::matching(all_of![
@@ -424,7 +441,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken2", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken2",
+        tok.token().expect("should have access token")
+    );
 
     server.expect(
         Expectation::matching(all_of![
@@ -445,7 +465,10 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!("accesstoken3", tok.token().expect("should have access token"));
+    assert_eq!(
+        "accesstoken3",
+        tok.token().expect("should have access token")
+    );
 
     // Refresh fails, but renewing the token succeeds.
     // PR #165
@@ -477,9 +500,7 @@ async fn test_refresh() {
         }))),
     );
 
-    let tok_err = auth
-        .token(&["https://googleapis.com/some/scope"])
-        .await;
+    let tok_err = auth.token(&["https://googleapis.com/some/scope"]).await;
     assert!(tok_err.is_ok());
 }
 
@@ -515,7 +536,10 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        token1.token().expect("should have access token"),
+        "accesstoken"
+    );
     assert_eq!(token1, token2);
 
     // Create a new authenticator. This authenticator does not share a cache
@@ -541,7 +565,10 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token3.token().expect("should have access token"), "accesstoken2");
+    assert_eq!(
+        token3.token().expect("should have access token"),
+        "accesstoken2"
+    );
 }
 
 #[tokio::test]
@@ -583,7 +610,10 @@ async fn test_disk_storage() {
             .token(&["https://googleapis.com/some/scope"])
             .await
             .expect("failed to get token");
-        assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+        assert_eq!(
+            token1.token().expect("should have access token"),
+            "accesstoken"
+        );
         assert_eq!(token1, token2);
     }
 
@@ -605,7 +635,10 @@ async fn test_disk_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        token1.token().expect("should have access token"),
+        "accesstoken"
+    );
     assert_eq!(token1, token2);
 }
 
@@ -632,8 +665,14 @@ async fn test_default_application_credentials_from_metadata_server() {
 
     let opts = ApplicationDefaultCredentialsFlowOpts {
         metadata_url: Some(server.url("/token").to_string()),
+        ..Default::default()
     };
-    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(opts, DefaultHyperClient.build_test_hyper_client()).await {
+    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(
+        opts,
+        DefaultHyperClient.build_test_hyper_client(),
+    )
+    .await
+    {
         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await.unwrap(),
         _ => panic!("We are not testing service account adc model"),
     };
@@ -641,18 +680,25 @@ async fn test_default_application_credentials_from_metadata_server() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(access_token.token().expect("should have access token"), "accesstoken");
+    assert_eq!(
+        access_token.token().expect("should have access token"),
+        "accesstoken"
+    );
 }
 
 #[tokio::test]
 async fn test_token() {
-    let authenticator = AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
-	.build()
-	.await
-	.unwrap();
+    let authenticator =
+        AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
+            .build()
+            .await
+            .unwrap();
     let access_token = authenticator
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(access_token.token().expect("should have access token"), "0815".to_string());
+    assert_eq!(
+        access_token.token().expect("should have access token"),
+        "0815".to_string()
+    );
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,10 +1,10 @@
 use yup_oauth2::{
     authenticator::{DefaultAuthenticator, DefaultHyperClient, HyperClientBuilder},
     authenticator_delegate::{DeviceAuthResponse, DeviceFlowDelegate, InstalledFlowDelegate},
-    AccessTokenAuthenticator, ApplicationDefaultCredentialsAuthenticator,
-    ApplicationDefaultCredentialsFlowOpts, ApplicationSecret, DeviceFlowAuthenticator,
-    InstalledFlowAuthenticator, InstalledFlowReturnMethod, ServiceAccountAuthenticator,
-    ServiceAccountKey,
+    ApplicationDefaultCredentialsAuthenticator, ApplicationDefaultCredentialsFlowOpts,
+    ApplicationSecret, DeviceFlowAuthenticator, InstalledFlowAuthenticator,
+    InstalledFlowReturnMethod, ServiceAccountAuthenticator, ServiceAccountKey,
+    AccessTokenAuthenticator,
 };
 
 use std::future::Future;
@@ -93,10 +93,7 @@ async fn test_device_success() {
         .token(&["https://www.googleapis.com/scope/1"])
         .await
         .expect("token failed");
-    assert_eq!(
-        "accesstoken",
-        token.token().expect("should have access token")
-    );
+    assert_eq!("accesstoken", token.token().expect("should have access token"));
 }
 
 #[tokio::test]
@@ -218,7 +215,7 @@ async fn create_installed_flow_auth(
         }
     }
 
-    let client = DefaultHyperClient.build_test_hyper_client();
+    let client =  DefaultHyperClient.build_test_hyper_client();
     let mut builder = InstalledFlowAuthenticator::with_client(app_secret, method, client.clone())
         .flow_delegate(Box::new(FD(client)));
 
@@ -257,10 +254,7 @@ async fn test_installed_interactive_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        "accesstoken",
-        tok.token().expect("should have access token")
-    );
+    assert_eq!("accesstoken", tok.token().expect("should have access token"));
 }
 
 #[tokio::test]
@@ -289,10 +283,7 @@ async fn test_installed_redirect_success() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        "accesstoken",
-        tok.token().expect("should have access token")
-    );
+    assert_eq!("accesstoken", tok.token().expect("should have access token"));
 }
 
 #[tokio::test]
@@ -361,13 +352,8 @@ async fn test_service_account_success() {
         .token(&["https://www.googleapis.com/auth/pubsub"])
         .await
         .expect("token failed");
-    assert!(tok
-        .token()
-        .expect("should have access token")
-        .contains("ya29.c.ElouBywiys0Ly"));
-    assert!(
-        OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap()
-    );
+    assert!(tok.token().expect("should have access token").contains("ya29.c.ElouBywiys0Ly"));
+    assert!(OffsetDateTime::now_utc() + time::Duration::seconds(3600) >= tok.expiration_time().unwrap());
 }
 
 #[tokio::test]
@@ -417,10 +403,7 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        "accesstoken",
-        tok.token().expect("should have access token")
-    );
+    assert_eq!("accesstoken", tok.token().expect("should have access token"));
 
     server.expect(
         Expectation::matching(all_of![
@@ -441,10 +424,7 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        "accesstoken2",
-        tok.token().expect("should have access token")
-    );
+    assert_eq!("accesstoken2", tok.token().expect("should have access token"));
 
     server.expect(
         Expectation::matching(all_of![
@@ -465,10 +445,7 @@ async fn test_refresh() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        "accesstoken3",
-        tok.token().expect("should have access token")
-    );
+    assert_eq!("accesstoken3", tok.token().expect("should have access token"));
 
     // Refresh fails, but renewing the token succeeds.
     // PR #165
@@ -500,7 +477,9 @@ async fn test_refresh() {
         }))),
     );
 
-    let tok_err = auth.token(&["https://googleapis.com/some/scope"]).await;
+    let tok_err = auth
+        .token(&["https://googleapis.com/some/scope"])
+        .await;
     assert!(tok_err.is_ok());
 }
 
@@ -536,10 +515,7 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        token1.token().expect("should have access token"),
-        "accesstoken"
-    );
+    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
     assert_eq!(token1, token2);
 
     // Create a new authenticator. This authenticator does not share a cache
@@ -565,10 +541,7 @@ async fn test_memory_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        token3.token().expect("should have access token"),
-        "accesstoken2"
-    );
+    assert_eq!(token3.token().expect("should have access token"), "accesstoken2");
 }
 
 #[tokio::test]
@@ -610,10 +583,7 @@ async fn test_disk_storage() {
             .token(&["https://googleapis.com/some/scope"])
             .await
             .expect("failed to get token");
-        assert_eq!(
-            token1.token().expect("should have access token"),
-            "accesstoken"
-        );
+        assert_eq!(token1.token().expect("should have access token"), "accesstoken");
         assert_eq!(token1, token2);
     }
 
@@ -635,10 +605,7 @@ async fn test_disk_storage() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .expect("failed to get token");
-    assert_eq!(
-        token1.token().expect("should have access token"),
-        "accesstoken"
-    );
+    assert_eq!(token1.token().expect("should have access token"), "accesstoken");
     assert_eq!(token1, token2);
 }
 
@@ -665,14 +632,8 @@ async fn test_default_application_credentials_from_metadata_server() {
 
     let opts = ApplicationDefaultCredentialsFlowOpts {
         metadata_url: Some(server.url("/token").to_string()),
-        ..Default::default()
     };
-    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(
-        opts,
-        DefaultHyperClient.build_test_hyper_client(),
-    )
-    .await
-    {
+    let authenticator = match ApplicationDefaultCredentialsAuthenticator::with_client(opts, DefaultHyperClient.build_test_hyper_client()).await {
         ApplicationDefaultCredentialsTypes::InstanceMetadata(auth) => auth.build().await.unwrap(),
         _ => panic!("We are not testing service account adc model"),
     };
@@ -680,25 +641,18 @@ async fn test_default_application_credentials_from_metadata_server() {
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(
-        access_token.token().expect("should have access token"),
-        "accesstoken"
-    );
+    assert_eq!(access_token.token().expect("should have access token"), "accesstoken");
 }
 
 #[tokio::test]
 async fn test_token() {
-    let authenticator =
-        AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
-            .build()
-            .await
-            .unwrap();
+    let authenticator = AccessTokenAuthenticator::with_client("0815".to_string(), DefaultHyperClient)
+	.build()
+	.await
+	.unwrap();
     let access_token = authenticator
         .token(&["https://googleapis.com/some/scope"])
         .await
         .unwrap();
-    assert_eq!(
-        access_token.token().expect("should have access token"),
-        "0815".to_string()
-    );
+    assert_eq!(access_token.token().expect("should have access token"), "0815".to_string());
 }


### PR DESCRIPTION
This adds support for getting an ID token (as opposed to an oauth2 access token) from Google's metadata service.

Edit: it's a breaking change because it added a field to a public struct. Maybe it's worth marking the option structs as `non_exhaustive` to make such changes less disruptive in the future?