### PR TITLE
Upgrade to hyper-rustls 0.25

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ base64 = "0.21"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "server", "tcp", "http2"] }
-hyper-rustls = { version = "0.24", optional = true, features = ["http2"] }
+hyper-rustls = { version = "0.25", optional = true, features = ["http2"] }
 hyper-tls = { version = "0.5.0", optional = true }
 itertools = "0.12"
 log = "0.4"
@@ -57,7 +57,7 @@ httptest = "0.15"
 env_logger = "0.10"
 tempfile = "3.1"
 webbrowser = "0.8"
-hyper-rustls = "0.24"
+hyper-rustls = "0.25"
 
 [workspace]
 members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/test-adc"]

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -44,6 +44,7 @@ async fn main() {
     let client = hyper::Client::builder().build(
         hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
+            .expect("failed to find native root certificates")
             .https_only()
             .enable_http1()
             .enable_http2()

--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -249,6 +249,7 @@ mod tests {
         let client = hyper::Client::builder().build(
             hyper_rustls::HttpsConnectorBuilder::new()
                 .with_native_roots()
+                .unwrap()
                 .https_only()
                 .enable_http1()
                 .enable_http2()


### PR DESCRIPTION
Would be nice to have a release that supports hyper-rustls 0.25 (which in turn depends on rustls 0.22). I would like to use this for opentelemetry-stackdriver, which is due for a new release.

(hyper-rustls 0.26 has been released which depends on hyper 1 instead of hyper 0.14. That is a bit of a bigger change that I'm not quite ready to address yet.)