### PR TITLE
make Authenticator.find_token_info public

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -105,7 +105,7 @@ where
     }
 
     /// Return a cached token or fetch a new one from the server.
-    async fn find_token_info<'a, T>(
+    pub async fn find_token_info<'a, T>(
         &'a self,
         scopes: &'a [T],
         force_refresh: bool,


### PR DESCRIPTION
Making this method public allows the client to save the refresh token for later use