### PR TITLE
Upgrade hyper to 1.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ base64 = "0.22"
 futures = "0.3"
 http = "1"
 http-body-util = "0.1"
-hyper = { version = "1", features = ["http2"] }
-hyper-util = "0.1"
+hyper = "1"
+hyper-util = { version = "0.1.5", features = ["client-legacy", "server-auto", "http1", "http2", "server-graceful"] }
 hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http2"] }
 hyper-tls = { version = "0.6.0", optional = true }
 itertools = "0.12"
@@ -47,18 +47,17 @@ percent-encoding = "2"
 rustls = { version = "^0.23", optional = true, features = ["ring"] }
 rustls-pemfile = { version = "1.0.1", optional = true }
 seahash = "4"
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = { version = "0.3.7", features = ["local-offset", "parsing", "serde"] }
-tokio = { version = "1.0", features = ["fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
-tower-service = "^0.3.1"
+tokio = { version = "1.0", features = [ "fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
 url = "2"
 
 [dev-dependencies]
 httptest = "0.16"
-env_logger = "0.11"
+env_logger = "0.10"
 tempfile = "3.1"
-webbrowser = "1"
+webbrowser = "0.8"
 hyper-rustls = "0.27"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,14 +35,16 @@ anyhow = "1.0.38"
 async-trait = "^0.1"
 base64 = "0.22"
 futures = "0.3"
-http = "0.2"
-hyper = { version = "0.14", features = ["client", "server", "tcp", "http2"] }
-hyper-rustls = { version = "0.25", optional = true, features = ["http2"] }
-hyper-tls = { version = "0.5.0", optional = true }
+http = "1"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["http2"] }
+hyper-util = "0.1"
+hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http2"] }
+hyper-tls = { version = "0.6.0", optional = true }
 itertools = "0.12"
 log = "0.4"
 percent-encoding = "2"
-rustls = { version = "^0.22.1", optional = true }
+rustls = { version = "^0.23", optional = true, features = ["ring"] }
 rustls-pemfile = { version = "1.0.1", optional = true }
 seahash = "4"
 serde = {version = "1.0", features = ["derive"]}
@@ -53,11 +55,11 @@ tower-service = "^0.3.1"
 url = "2"
 
 [dev-dependencies]
-httptest = "0.15"
-env_logger = "0.10"
+httptest = "0.16"
+env_logger = "0.11"
 tempfile = "3.1"
-webbrowser = "0.8"
-hyper-rustls = "0.25"
+webbrowser = "1"
+hyper-rustls = "0.27"
 
 [workspace]
 members = ["examples/test-installed/", "examples/test-svc-acct/", "examples/test-device/", "examples/test-adc"]

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -8,12 +8,12 @@
 use std::error::Error as StdError;
 
 use http::Uri;
-use hyper::client::connect::Connection;
+use hyper_util::client::legacy::connect::Connection;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
 
 async fn r#use<S>(
-    client: hyper::Client<S>,
+    client: hyper_util::client::legacy::Client<S, String>,
     authenticator: yup_oauth2::authenticator::Authenticator<S>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 where
@@ -41,7 +41,7 @@ async fn main() {
     let secret = yup_oauth2::read_service_account_key(google_credentials)
         .await
         .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
-    let client = hyper::Client::builder().build(
+    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build(
         hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
             .expect("failed to find native root certificates")

--- a/examples/custom_client.rs
+++ b/examples/custom_client.rs
@@ -5,22 +5,14 @@
 //!
 //! It is also a better use of resources (memory, sockets, etc.)
 
-use std::error::Error as StdError;
+use hyper_util::client::legacy::connect::Connect;
 
-use http::Uri;
-use hyper_util::client::legacy::connect::Connection;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
-
-async fn r#use<S>(
-    client: hyper_util::client::legacy::Client<S, String>,
-    authenticator: yup_oauth2::authenticator::Authenticator<S>,
+async fn r#use<C>(
+    client: hyper_util::client::legacy::Client<C, String>,
+    authenticator: yup_oauth2::authenticator::Authenticator<C>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 where
-    S: Service<Uri> + Clone + Send + Sync + 'static,
-    S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    S::Future: Send + Unpin + 'static,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     let access_token = authenticator.token(&["email"]).await?;
     let request = http::Request::get("https://example.com")
@@ -28,7 +20,7 @@ where
             http::header::AUTHORIZATION,
             format!("Bearer {}", access_token.token().ok_or("no access token")?),
         )
-        .body(hyper::body::Body::empty())?;
+        .body(String::new())?;
     let response = client.request(request).await?;
     drop(response); // Implementing handling of the response is left as an exercise for the reader.
     Ok(())
@@ -41,15 +33,16 @@ async fn main() {
     let secret = yup_oauth2::read_service_account_key(google_credentials)
         .await
         .expect("$GOOGLE_APPLICATION_CREDENTIALS is not a valid service account key");
-    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build(
-        hyper_rustls::HttpsConnectorBuilder::new()
-            .with_native_roots()
-            .expect("failed to find native root certificates")
-            .https_only()
-            .enable_http1()
-            .enable_http2()
-            .build(),
-    );
+    let client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+        .build(
+            hyper_rustls::HttpsConnectorBuilder::new()
+                .with_native_roots()
+                .expect("failed to find native root certificates")
+                .https_only()
+                .enable_http1()
+                .enable_http2()
+                .build(),
+        );
     let authenticator =
         yup_oauth2::ServiceAccountAuthenticator::with_client(secret, client.clone())
             .build()

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -8,7 +8,7 @@
 use crate::error::Error;
 use crate::types::TokenInfo;
 use http::Uri;
-use hyper::client::connect::Connection;
+use hyper_util::client::legacy::connect::Connection;
 use std::error::Error as StdError;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::Service;
@@ -22,7 +22,7 @@ impl AccessTokenFlow {
     /// just return the access token
     pub(crate) async fn token<S, T>(
         &self,
-        _hyper_client: &hyper::Client<S>,
+        _hyper_client: &hyper_util::client::legacy::Client<S, String>,
         _scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where

--- a/src/access_token.rs
+++ b/src/access_token.rs
@@ -7,11 +7,7 @@
 //! access token of the other service by generating a new token.
 use crate::error::Error;
 use crate::types::TokenInfo;
-use http::Uri;
-use hyper_util::client::legacy::connect::Connection;
-use std::error::Error as StdError;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
+use hyper_util::client::legacy::connect::Connect;
 
 /// the flow for the access token authenticator
 pub struct AccessTokenFlow {
@@ -20,17 +16,14 @@ pub struct AccessTokenFlow {
 
 impl AccessTokenFlow {
     /// just return the access token
-    pub(crate) async fn token<S, T>(
+    pub(crate) async fn token<C, B, T>(
         &self,
-        _hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        _hyper_client: &hyper_util::client::legacy::Client<C, B>,
         _scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         Ok(TokenInfo {
             access_token: Some(self.access_token.clone()),

--- a/src/application_default_credentials.rs
+++ b/src/application_default_credentials.rs
@@ -1,11 +1,7 @@
 use crate::error::Error;
 use crate::types::TokenInfo;
-use http::Uri;
 use http_body_util::BodyExt;
-use hyper_util::client::legacy::connect::{Connect, Connection};
-use std::error::Error as StdError;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
+use hyper_util::client::legacy::connect::Connect;
 
 /// Provide options for the Application Default Credential Flow, mostly used for testing
 #[derive(Default, Clone, Debug)]
@@ -24,26 +20,23 @@ impl ApplicationDefaultCredentialsFlow {
         ApplicationDefaultCredentialsFlow { metadata_url }
     }
 
-    pub(crate) async fn token<S, T>(
+    pub(crate) async fn token<C, T>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Connect + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let scope = crate::helper::join(scopes, ",");
         let token_uri = format!("{}?scopes={}", self.metadata_url, scope);
-        let request = hyper::Request::get(token_uri)
+        let request = http::Request::get(token_uri)
             .header("Metadata-Flavor", "Google")
-            .body(String::new())
+            .body(String::new()) // why body is needed?
             .unwrap();
         log::debug!("requesting token from metadata server: {:?}", request);
-        let (head, body) = hyper_client.request(request).await.map_err(|err| Error::OtherError(err.into()))?.into_parts();
+        let (head, body) = hyper_client.request(request).await?.into_parts();
         let body = body.collect().await?.to_bytes();
         log::debug!("received response; head: {:?}, body: {:?}", head, body);
         TokenInfo::from_json(&body)

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -20,19 +20,15 @@ use private::AuthFlow;
 use crate::access_token::AccessTokenFlow;
 
 use futures::lock::Mutex;
-use http::Uri;
-use hyper_util::client::legacy::connect::Connection;
+use hyper_util::client::legacy::connect::Connect;
 use std::borrow::Cow;
-use std::error::Error as StdError;
 use std::fmt;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
 
-struct InnerAuthenticator<S> {
-    hyper_client: hyper_util::client::legacy::Client<S, String>,
+struct InnerAuthenticator<C> {
+    hyper_client: hyper_util::client::legacy::Client<C, String>,
     storage: Storage,
     auth_flow: AuthFlow,
 }
@@ -40,8 +36,8 @@ struct InnerAuthenticator<S> {
 /// Authenticator is responsible for fetching tokens, handling refreshing tokens,
 /// and optionally persisting tokens to disk.
 #[derive(Clone)]
-pub struct Authenticator<S> {
-    inner: Arc<InnerAuthenticator<S>>,
+pub struct Authenticator<C> {
+    inner: Arc<InnerAuthenticator<C>>,
 }
 
 struct DisplayScopes<'a, T>(&'a [T]);
@@ -63,12 +59,9 @@ where
     }
 }
 
-impl<S> Authenticator<S>
+impl<C> Authenticator<C>
 where
-    S: Service<Uri> + Clone + Send + Sync + 'static,
-    S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    S::Future: Send + Unpin + 'static,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     /// Return the current token for the provided scopes.
     pub async fn token<'a, T>(&'a self, scopes: &'a [T]) -> Result<AccessToken, Error>
@@ -544,7 +537,7 @@ impl ServiceAccountImpersonationAuthenticator {
 /// ```
 /// # #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
 /// # async fn foo() {
-/// # let custom_hyper_client = hyper_util::client::legacy::Client::new();
+/// # let custom_hyper_client = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build_http::<String>();
 /// # let app_secret = yup_oauth2::read_application_secret("/tmp/foo").await.unwrap();
 ///     let authenticator = yup_oauth2::DeviceFlowAuthenticator::builder(app_secret)
 ///         .hyper_client(custom_hyper_client)
@@ -604,10 +597,10 @@ impl<C, F> AuthenticatorBuilder<C, F> {
     }
 
     /// Use the provided hyper client.
-    pub fn hyper_client<NewC, B: hyper::body::Body>(
+    pub fn hyper_client<NewC>(
         self,
-        hyper_client: hyper_util::client::legacy::Client<NewC, B>,
-    ) -> AuthenticatorBuilder<hyper_util::client::legacy::Client<NewC, B>, F> {
+        hyper_client: hyper_util::client::legacy::Client<NewC, String>,
+    ) -> AuthenticatorBuilder<hyper_util::client::legacy::Client<NewC, String>, F> {
         AuthenticatorBuilder {
             hyper_client_builder: hyper_client,
             storage_type: self.storage_type,
@@ -874,7 +867,7 @@ impl<C> AuthenticatorBuilder<C, AccessTokenFlow> {
 mod private {
     use crate::access_token::AccessTokenFlow;
     use crate::application_default_credentials::ApplicationDefaultCredentialsFlow;
-    use crate::authenticator::{AsyncRead, AsyncWrite, Connection, Service, StdError, Uri};
+    use crate::authenticator::Connect;
     use crate::authorized_user::AuthorizedUserFlow;
     use crate::device::DeviceFlow;
     use crate::error::Error;
@@ -912,17 +905,14 @@ mod private {
             }
         }
 
-        pub(crate) async fn token<'a, S, T>(
+        pub(crate) async fn token<'a, C, T>(
             &'a self,
-            hyper_client: &'a hyper_util::client::legacy::Client<S, String>,
+            hyper_client: &'a hyper_util::client::legacy::Client<C, String>,
             scopes: &'a [T],
         ) -> Result<TokenInfo, Error>
         where
             T: AsRef<str>,
-            S: Service<Uri> + hyper_util::client::legacy::connect::Connect + Clone + Send + Sync + 'static,
-            S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-            S::Future: Send + Unpin + 'static,
-            S::Error: Into<Box<dyn StdError + Send + Sync>>,
+            C: Connect + Clone + Send + Sync + 'static,
         {
             match self {
                 AuthFlow::DeviceFlow(device_flow) => device_flow.token(hyper_client, scopes).await,
@@ -958,14 +948,17 @@ mod private {
 /// A trait implemented for any hyper_util::client::legacy::Client as well as the DefaultHyperClient.
 pub trait HyperClientBuilder {
     /// The hyper connector that the resulting hyper client will use.
-    type Connector: Service<Uri> + Clone + Send + Sync + 'static;
+    type Connector: Connect + Clone + Send + Sync + 'static;
 
-    /// Create a hyper_util::client::legacy::Client
-    fn build_hyper_client(self) -> Result<hyper_util::client::legacy::Client<Self::Connector, String>, Error>;
+    /// Create a hyper::Client
+    fn build_hyper_client(
+        self,
+    ) -> Result<hyper_util::client::legacy::Client<Self::Connector, String>, Error>;
 
     /// Create a `hyper_util::client::legacy::Client` for tests (HTTPS not required)
     #[doc(hidden)]
-    fn build_test_hyper_client(self) -> hyper_util::client::legacy::Client<Self::Connector, String>;
+    fn build_test_hyper_client(self)
+        -> hyper_util::client::legacy::Client<Self::Connector, String>;
 }
 
 #[cfg(feature = "hyper-rustls")]
@@ -984,7 +977,7 @@ pub type DefaultAuthenticator =
 )]
 /// Default authenticator type
 pub type DefaultAuthenticator =
-    Authenticator<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>;
+    Authenticator<hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>>;
 
 /// The builder value used when the default hyper client should be used.
 #[cfg(any(feature = "hyper-rustls", feature = "hyper-tls"))]
@@ -1001,11 +994,14 @@ pub struct DefaultHyperClient;
 )]
 impl HyperClientBuilder for DefaultHyperClient {
     #[cfg(feature = "hyper-rustls")]
-    type Connector = hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>;
+    type Connector =
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>;
     #[cfg(all(not(feature = "hyper-rustls"), feature = "hyper-tls"))]
     type Connector = hyper_tls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>;
 
-    fn build_hyper_client(self) -> Result<hyper_util::client::legacy::Client<Self::Connector, String>, Error> {
+    fn build_hyper_client(
+        self,
+    ) -> Result<hyper_util::client::legacy::Client<Self::Connector, String>, Error> {
         #[cfg(feature = "hyper-rustls")]
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()?
@@ -1016,12 +1012,16 @@ impl HyperClientBuilder for DefaultHyperClient {
         #[cfg(all(not(feature = "hyper-rustls"), feature = "hyper-tls"))]
         let connector = hyper_tls::HttpsConnector::new();
 
-        Ok(hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-            .pool_max_idle_per_host(0)
-            .build::<_, _>(connector))
+        Ok(
+            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+                .pool_max_idle_per_host(0)
+                .build::<_, String>(connector),
+        )
     }
 
-    fn build_test_hyper_client(self) -> hyper_util::client::legacy::Client<Self::Connector, String> {
+    fn build_test_hyper_client(
+        self,
+    ) -> hyper_util::client::legacy::Client<Self::Connector, String> {
         #[cfg(feature = "hyper-rustls")]
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
@@ -1035,24 +1035,23 @@ impl HyperClientBuilder for DefaultHyperClient {
 
         hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
             .pool_max_idle_per_host(0)
-            .build::<_, _>(connector)
+            .build::<_, String>(connector)
     }
 }
 
-impl<S> HyperClientBuilder for hyper_util::client::legacy::Client<S, String>
+impl<C> HyperClientBuilder for hyper_util::client::legacy::Client<C, String>
 where
-    S: Service<Uri> + Clone + Send + Sync + 'static,
-    S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    S::Future: Send + Unpin + 'static,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    C: Connect + Clone + Send + Sync + 'static,
 {
-    type Connector = S;
+    type Connector = C;
 
-    fn build_hyper_client(self) -> Result<hyper_util::client::legacy::Client<S, String>, Error> {
+    fn build_hyper_client(self) -> Result<hyper_util::client::legacy::Client<C, String>, Error> {
         Ok(self)
     }
 
-    fn build_test_hyper_client(self) -> hyper_util::client::legacy::Client<Self::Connector, String> {
+    fn build_test_hyper_client(
+        self,
+    ) -> hyper_util::client::legacy::Client<Self::Connector, String> {
         self
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -5,15 +5,11 @@ use crate::error::{AuthError, Error};
 use crate::types::{ApplicationSecret, TokenInfo};
 
 use std::borrow::Cow;
-use std::error::Error as StdError;
 use std::time::Duration;
 
-use http::Uri;
+use http::header;
 use http_body_util::BodyExt;
-use hyper_util::client::legacy::connect::{Connect, Connection};
-use hyper::header;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
+use hyper_util::client::legacy::connect::Connect;
 use url::form_urlencoded;
 
 pub const GOOGLE_DEVICE_CODE_URL: &str = "https://accounts.google.com/o/oauth2/device/code";
@@ -44,17 +40,14 @@ impl DeviceFlow {
         }
     }
 
-    pub(crate) async fn token<S, T>(
+    pub(crate) async fn token<C, T>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let device_auth_resp = Self::request_code(
             &self.app_secret,
@@ -76,18 +69,15 @@ impl DeviceFlow {
         .await
     }
 
-    async fn wait_for_device_token<S>(
+    async fn wait_for_device_token<C>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         app_secret: &ApplicationSecret,
         device_auth_resp: &DeviceAuthResponse,
         grant_type: &str,
     ) -> Result<TokenInfo, Error>
     where
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let mut interval = device_auth_resp.interval;
         log::debug!("Polling every {:?} for device token", interval);
@@ -136,18 +126,15 @@ impl DeviceFlow {
     /// * If called after a successful result was returned at least once.
     /// # Examples
     /// See test-cases in source code for a more complete example.
-    async fn request_code<S, T>(
+    async fn request_code<C, T>(
         application_secret: &ApplicationSecret,
-        client: &hyper_util::client::legacy::Client<S, String>,
+        client: &hyper_util::client::legacy::Client<C, String>,
         device_code_url: &str,
         scopes: &[T],
     ) -> Result<DeviceAuthResponse, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Connect + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let req = form_urlencoded::Serializer::new(String::new())
             .extend_pairs(&[
@@ -158,12 +145,12 @@ impl DeviceFlow {
 
         // note: works around bug in rustlang
         // https://github.com/rust-lang/rust/issues/22252
-        let req = hyper::Request::post(device_code_url)
+        let req = http::Request::post(device_code_url)
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(req)
             .unwrap();
         log::debug!("requesting code from server: {:?}", req);
-        let (head, body) = client.request(req).await.map_err(|err| Error::OtherError(err.into()))?.into_parts();
+        let (head, body) = client.request(req).await?.into_parts();
         let body = body.collect().await?.to_bytes();
         log::debug!("received response; head: {:?}, body: {:?}", head, body);
         DeviceAuthResponse::from_json(&body)
@@ -187,17 +174,14 @@ impl DeviceFlow {
     ///
     /// # Examples
     /// See test-cases in source code for a more complete example.
-    async fn poll_token<'a, S>(
+    async fn poll_token<'a, C>(
         application_secret: &ApplicationSecret,
-        client: &hyper_util::client::legacy::Client<S, String>,
+        client: &hyper_util::client::legacy::Client<C, String>,
         device_code: &str,
         grant_type: &str,
     ) -> Result<TokenInfo, Error>
     where
-        S: Service<Uri> + Connect + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         // We should be ready for a new request
         let req = form_urlencoded::Serializer::new(String::new())
@@ -209,12 +193,12 @@ impl DeviceFlow {
             ])
             .finish();
 
-        let request = hyper::Request::post(&application_secret.token_uri)
+        let request = http::Request::post(&application_secret.token_uri)
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(req)
-            .map_err(|err| Error::OtherError(err.into()))?;
+            .unwrap(); // TODO: Error checking
         log::debug!("polling for token: {:?}", request);
-        let (head, body) = client.request(request).await.map_err(|err| Error::OtherError(err.into()))?.into_parts();
+        let (head, body) = client.request(request).await?.into_parts();
         let body = body.collect().await?.to_bytes();
         log::debug!("received response; head: {:?} body: {:?}", head, body);
         TokenInfo::from_json(&body)

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,6 +146,8 @@ impl<T> AuthErrorOr<T> {
 pub enum Error {
     /// Indicates connection failure
     HttpError(hyper::Error),
+    /// Indicates connection failure
+    HttpClientError(hyper_util::client::legacy::Error),
     /// The server returned an error.
     AuthError(AuthError),
     /// Error while decoding a JSON response.
@@ -163,6 +165,12 @@ pub enum Error {
 impl From<hyper::Error> for Error {
     fn from(error: hyper::Error) -> Error {
         Error::HttpError(error)
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for Error {
+    fn from(error: hyper_util::client::legacy::Error) -> Error {
+        Error::HttpClientError(error)
     }
 }
 
@@ -197,6 +205,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match *self {
             Error::HttpError(ref err) => err.fmt(f),
+            Error::HttpClientError(ref err) => err.fmt(f),
             Error::AuthError(ref err) => err.fmt(f),
             Error::JSONError(ref e) => {
                 write!(
@@ -224,6 +233,7 @@ impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
         match *self {
             Error::HttpError(ref err) => Some(err),
+            Error::HttpClientError(ref err) => Some(err),
             Error::AuthError(ref err) => Some(err),
             Error::JSONError(ref err) => Some(err),
             Error::LowLevelError(ref err) => Some(err),

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -7,19 +7,15 @@ use crate::error::Error;
 use crate::types::{ApplicationSecret, TokenInfo};
 
 use futures::lock::Mutex;
+use http_body_util::BodyExt;
 use std::convert::AsRef;
-use std::error::Error as StdError;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use http::Uri;
-use http_body_util::BodyExt;
-use hyper_util::client::legacy::connect::{Connect, Connection};
-use hyper::header;
+use http::header;
+use hyper_util::client::legacy::connect::Connect;
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::oneshot;
-use tower_service::Service;
 use url::form_urlencoded;
 
 const QUERY_SET: AsciiSet = CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
@@ -123,17 +119,14 @@ impl InstalledFlow {
     /// . Return that token
     ///
     /// It's recommended not to use the DefaultInstalledFlowDelegate, but a specialized one.
-    pub(crate) async fn token<S, T>(
+    pub(crate) async fn token<C, T>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         match self.method {
             InstalledFlowReturnMethod::HTTPRedirect => {
@@ -151,18 +144,15 @@ impl InstalledFlow {
         }
     }
 
-    async fn ask_auth_code_interactively<S, T>(
+    async fn ask_auth_code_interactively<C, T>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         app_secret: &ApplicationSecret,
         scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let url = build_authentication_request_url(
             &app_secret.auth_uri,
@@ -182,19 +172,16 @@ impl InstalledFlow {
             .await
     }
 
-    async fn ask_auth_code_via_http<S, T>(
+    async fn ask_auth_code_via_http<C, T>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         port: Option<u16>,
         app_secret: &ApplicationSecret,
         scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         use std::borrow::Cow;
         let server = InstalledFlowServer::run(port)?;
@@ -224,23 +211,20 @@ impl InstalledFlow {
             .await
     }
 
-    async fn exchange_auth_code<S>(
+    async fn exchange_auth_code<C>(
         &self,
         authcode: &str,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         app_secret: &ApplicationSecret,
         server_addr: Option<SocketAddr>,
     ) -> Result<TokenInfo, Error>
     where
-        S: Service<Uri> + Connect + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let redirect_uri = self.flow_delegate.redirect_uri();
         let request = Self::request_token(app_secret, authcode, redirect_uri, server_addr);
         log::debug!("Sending request: {:?}", request);
-        let (head, body) = hyper_client.request(request).await.map_err(|err| Error::OtherError(err.into()))?.into_parts();
+        let (head, body) = hyper_client.request(request).await?.into_parts();
         let body = body.collect().await?.to_bytes();
         log::debug!("Received response; head: {:?} body: {:?}", head, body);
         TokenInfo::from_json(&body)
@@ -252,7 +236,7 @@ impl InstalledFlow {
         authcode: &str,
         custom_redirect_uri: Option<&str>,
         server_addr: Option<SocketAddr>,
-    ) -> hyper::Request<String> {
+    ) -> http::Request<String> {
         use std::borrow::Cow;
         let redirect_uri: Cow<str> = match (custom_redirect_uri, server_addr) {
             (Some(uri), _) => uri.into(),
@@ -270,9 +254,9 @@ impl InstalledFlow {
             ])
             .finish();
 
-        hyper::Request::post(&app_secret.token_uri)
+        http::Request::post(&app_secret.token_uri)
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
-            .body(String::from(body))
+            .body(body)
             .unwrap() // TODO: error check
     }
 }
@@ -286,43 +270,62 @@ struct InstalledFlowServer {
 
 impl InstalledFlowServer {
     fn run(port: Option<u16>) -> Result<Self, Error> {
-        use hyper::service::{service_fn};
         let (auth_code_tx, auth_code_rx) = oneshot::channel::<String>();
-        let (trigger_shutdown_tx, trigger_shutdown_rx) = oneshot::channel::<()>();
+        let (trigger_shutdown_tx, mut trigger_shutdown_rx) = oneshot::channel::<()>();
         let auth_code_tx = Arc::new(Mutex::new(Some(auth_code_tx)));
 
-        let service = move |_| {
-            let auth_code_tx = auth_code_tx.clone();
-            async move {
-                use std::convert::Infallible;
-                Ok::<_, Infallible>(service_fn(move |req| {
-                    installed_flow_server::handle_req(req, auth_code_tx.clone())
-                }))
-            }
-        };
+        let service = hyper::service::service_fn(move |req| {
+            installed_flow_server::handle_req(req, auth_code_tx.clone())
+        });
+
         let addr: std::net::SocketAddr = match port {
             Some(port) => ([127, 0, 0, 1], port).into(),
             None => ([127, 0, 0, 1], 0).into(),
         };
-        // start with std::net because tokio's bind is async
-        let listener = std::net::TcpListener::bind(addr)?;
-        listener.set_nonblocking(true)?;
-        let addr = listener.local_addr()?;
-        let listener = tokio::net::TcpListener::from_std(listener)?;
+
+        let server =
+            hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
+                .http1_only();
+        let graceful = hyper_util::server::graceful::GracefulShutdown::new();
+
+        let std_listener = std::net::TcpListener::bind(addr)?;
+        std_listener.set_nonblocking(true)?;
+        let addr = std_listener.local_addr()?;
+        let tcp_server = tokio::net::TcpListener::from_std(std_listener)?;
+
+        log::debug!("HTTP server listening on {}", addr);
+
         let shutdown_complete = tokio::spawn(async move {
-            let server = hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new());
             loop {
-                tokio::select! {
-                    biased;
-                    _ = trigger_shutdown_rx => break,
-                    Ok((tcp, _)) = listener.accept() => {
-                        server.serve_connection(hyper_util::rt::TokioIo::new(tcp), service);
+                let conn = tokio::select! {
+                    Ok((conn,_)) = tcp_server.accept() => conn,
+                    _ = &mut trigger_shutdown_rx => break,
+                    else => break,
+                };
+
+                let conn = server
+                    .serve_connection(hyper_util::rt::TokioIo::new(conn), service.clone())
+                    .into_owned();
+
+                let conn = graceful.watch(conn);
+
+                tokio::spawn(async move {
+                    if let Err(err) = conn.await {
+                        log::debug!("connection error: {err}");
                     }
+                });
+            }
+
+            tokio::select! {
+                _ = graceful.shutdown() => {
+                     log::debug!("Gracefully shutdown!");
+                },
+                _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {
+                     log::debug!("Waited 10 seconds for graceful shutdown, aborting...");
                 }
             }
         });
 
-        log::debug!("HTTP server listening on {}", addr);
         Ok(InstalledFlowServer {
             addr,
             auth_code_rx,
@@ -353,13 +356,13 @@ impl InstalledFlowServer {
 
 mod installed_flow_server {
     use futures::lock::Mutex;
-    use hyper::{Request, Response, StatusCode, Uri};
+    use http::{Request, Response, StatusCode, Uri};
     use std::sync::Arc;
     use tokio::sync::oneshot;
     use url::form_urlencoded;
 
-    pub(super) async fn handle_req(
-        req: Request<String>,
+    pub(super) async fn handle_req<B: hyper::body::Body>(
+        req: Request<B>,
         auth_code_tx: Arc<Mutex<Option<oneshot::Sender<String>>>>,
     ) -> Result<Response<String>, http::Error> {
         match req.uri().path_and_query() {
@@ -374,7 +377,7 @@ mod installed_flow_server {
                     .build();
 
                 match url {
-                    Err(_) => hyper::Response::builder()
+                    Err(_) => http::Response::builder()
                         .status(StatusCode::BAD_REQUEST)
                         .body(String::from("Unparseable URL")),
                     Ok(url) => match auth_code_from_url(url) {
@@ -382,26 +385,26 @@ mod installed_flow_server {
                             if let Some(sender) = auth_code_tx.lock().await.take() {
                                 let _ = sender.send(auth_code);
                             }
-                            hyper::Response::builder().status(StatusCode::OK).body(
-                                String::from(
+                            http::Response::builder()
+                                .status(StatusCode::OK)
+                                .body(String::from(
                                     "<html><head><title>Success</title></head><body>You may now \
                                      close this window.</body></html>",
-                                ),
-                            )
+                                ))
                         }
-                        None => hyper::Response::builder()
+                        None => http::Response::builder()
                             .status(StatusCode::BAD_REQUEST)
                             .body(String::from("No `code` in URL")),
                     },
                 }
             }
-            None => hyper::Response::builder()
+            None => http::Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .body(String::from("Invalid Request!")),
         }
     }
 
-    fn auth_code_from_url(url: hyper::Uri) -> Option<String> {
+    fn auth_code_from_url(url: http::Uri) -> Option<String> {
         // The provider redirects to the specified localhost URL, appending the authorization
         // code, like this: http://localhost:8080/xyz/?code=4/731fJ3BheyCouCniPufAd280GHNV5Ju35yYcGs
         form_urlencoded::parse(url.query().unwrap_or("").as_bytes()).find_map(|(param, val)| {
@@ -417,7 +420,7 @@ mod installed_flow_server {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyper::Uri;
+    use http::Uri;
 
     #[test]
     fn test_request_url_builder() {
@@ -467,9 +470,7 @@ mod tests {
         let (tx, rx) = oneshot::channel();
         // URLs are usually a bit botched
         let url: Uri = "http://example.com:1234/?code=ab/c%2Fd#".parse().unwrap();
-        let req = hyper::Request::get(url)
-            .body(hyper::body::Body::empty())
-            .unwrap();
+        let req = http::Request::get(url).body(String::new()).unwrap();
         installed_flow_server::handle_req(req, Arc::new(Mutex::new(Some(tx))))
             .await
             .unwrap();
@@ -478,8 +479,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_server() {
-        let client: hyper_util::client::legacy::Client<hyper::client::HttpConnector, hyper::Body> =
-            hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build_http();
+        let client: hyper_util::client::legacy::Client<
+            hyper_util::client::legacy::connect::HttpConnector,
+            String,
+        > = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
+            .build_http();
         let server = InstalledFlowServer::run(None).unwrap();
 
         let response = client

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1,13 +1,9 @@
 use crate::error::Error;
 use crate::types::{ApplicationSecret, TokenInfo};
 
-use http::Uri;
+use http::header;
 use http_body_util::BodyExt;
-use hyper_util::client::legacy::connect::{Connect, Connection};
-use hyper::header;
-use std::error::Error as StdError;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
+use hyper_util::client::legacy::connect::Connect;
 use url::form_urlencoded;
 
 /// Implements the [OAuth2 Refresh Token Flow](https://developers.google.com/youtube/v3/guides/authentication#devices).
@@ -32,16 +28,13 @@ impl RefreshFlow {
     ///
     /// # Examples
     /// Please see the crate landing page for an example.
-    pub(crate) async fn refresh_token<S>(
-        client: &hyper_util::client::legacy::Client<S, String>,
+    pub(crate) async fn refresh_token<C>(
+        client: &hyper_util::client::legacy::Client<C, String>,
         client_secret: &ApplicationSecret,
         refresh_token: &str,
     ) -> Result<TokenInfo, Error>
     where
-        S: Service<Uri> + Connect + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         log::debug!(
             "refreshing access token with refresh token: {}",
@@ -56,12 +49,12 @@ impl RefreshFlow {
             ])
             .finish();
 
-        let request = hyper::Request::post(&client_secret.token_uri)
+        let request = http::Request::post(&client_secret.token_uri)
             .header(header::CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(req)
             .unwrap();
         log::debug!("Sending request: {:?}", request);
-        let (head, body) = client.request(request).await.map_err(|err| Error::OtherError(err.into()))?.into_parts();
+        let (head, body) = client.request(request).await?.into_parts();
         let body = body.collect().await?.to_bytes();
         log::debug!("Received response; head: {:?}, body: {:?}", head, body);
         let mut token = TokenInfo::from_json(&body)?;

--- a/src/service_account_impersonator.rs
+++ b/src/service_account_impersonator.rs
@@ -4,13 +4,10 @@
 //! Resources:
 //! - [service account impersonation](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct#sa-credentials-oauth)
 
-use http::{header, Uri};
+use http::header;
 use http_body_util::BodyExt;
-use hyper_util::client::legacy::connect::{Connect, Connection};
+use hyper_util::client::legacy::connect::Connect;
 use serde::Serialize;
-use std::error::Error as StdError;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tower_service::Service;
 
 use crate::{
     authorized_user::{AuthorizedUserFlow, AuthorizedUserSecret},
@@ -122,17 +119,14 @@ impl ServiceAccountImpersonationFlow {
         }
     }
 
-    pub(crate) async fn token<S, T>(
+    pub(crate) async fn token<C, T>(
         &self,
-        hyper_client: &hyper_util::client::legacy::Client<S, String>,
+        hyper_client: &hyper_util::client::legacy::Client<C, String>,
         scopes: &[T],
     ) -> Result<TokenInfo, Error>
     where
         T: AsRef<str>,
-        S: Service<Uri> + Clone + Send + Sync + 'static,
-        S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-        S::Future: Send + Unpin + 'static,
-        S::Error: Into<Box<dyn StdError + Send + Sync>>,
+        C: Connect + Clone + Send + Sync + 'static,
     {
         let inner_token = self
             .inner_flow
@@ -159,18 +153,18 @@ fn access_request(
     uri: &str,
     inner_token: &str,
     scopes: &[&str],
-) -> Result<hyper::Request<String>, Error> {
+) -> Result<http::Request<String>, Error> {
     let req_body = Request {
         scope: scopes,
         // Max validity is 1h.
         lifetime: "3600s",
     };
-    let req_body = serde_json::to_vec(&req_body)?;
-    Ok(hyper::Request::post(uri)
+    let req_body = serde_json::to_string(&req_body)?;
+    Ok(http::Request::post(uri)
         .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
         .header(header::CONTENT_LENGTH, req_body.len())
         .header(header::AUTHORIZATION, format!("Bearer {}", inner_token))
-        .body(String::from_utf8_lossy(&req_body).into_owned())
+        .body(req_body)
         .unwrap())
 }
 
@@ -178,24 +172,24 @@ fn id_request(
     uri: &str,
     inner_token: &str,
     scopes: &[&str],
-) -> Result<hyper::Request<String>, Error> {
+) -> Result<http::Request<String>, Error> {
     // Only one audience is supported.
     let audience = scopes.first().unwrap_or(&"");
     let req_body = IdRequest {
         audience,
         include_email: true,
     };
-    let req_body = serde_json::to_vec(&req_body)?;
-    Ok(hyper::Request::post(uri)
+    let req_body = serde_json::to_string(&req_body)?;
+    Ok(http::Request::post(uri)
         .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
         .header(header::CONTENT_LENGTH, req_body.len())
         .header(header::AUTHORIZATION, format!("Bearer {}", inner_token))
-        .body(String::from_utf8_lossy(&req_body).into_owned())
+        .body(req_body)
         .unwrap())
 }
 
-pub(crate) async fn token_impl<S, T>(
-    hyper_client: &hyper_util::client::legacy::Client<S, String>,
+pub(crate) async fn token_impl<C, T>(
+    hyper_client: &hyper_util::client::legacy::Client<C, String>,
     uri: &str,
     access_token: bool,
     inner_token: &str,
@@ -203,10 +197,7 @@ pub(crate) async fn token_impl<S, T>(
 ) -> Result<TokenInfo, Error>
 where
     T: AsRef<str>,
-    S: Service<Uri> + Connect + Clone + Send + Sync + 'static,
-    S::Response: Connection + AsyncRead + AsyncWrite + Send + Unpin + 'static,
-    S::Future: Send + Unpin + 'static,
-    S::Error: Into<Box<dyn StdError + Send + Sync>>,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     let scopes: Vec<_> = scopes.iter().map(|s| s.as_ref()).collect();
     let request = if access_token {
@@ -216,7 +207,7 @@ where
     };
 
     log::debug!("requesting impersonated token {:?}", request);
-    let (head, body) = hyper_client.request(request).await.map_err(|err| Error::OtherError(err.into()))?.into_parts();
+    let (head, body) = hyper_client.request(request).await?.into_parts();
     let body = body.collect().await?.to_bytes();
     log::debug!("received response; head: {:?}, body: {:?}", head, body);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -11,8 +11,8 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 
+use http::Uri;
 use httptest::{matchers::*, responders::json_encoded, Expectation, Server};
-use hyper::Uri;
 use url::form_urlencoded;
 
 /// Utility function for parsing json. Useful in unit tests. Simply wrap the
@@ -55,6 +55,7 @@ async fn create_device_flow_auth(server: &Server) -> DefaultAuthenticator {
 #[tokio::test]
 async fn test_device_success() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     server.expect(
         Expectation::matching(all_of![
@@ -102,6 +103,7 @@ async fn test_device_success() {
 #[tokio::test]
 async fn test_device_no_code() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     server.expect(
         Expectation::matching(all_of![
@@ -126,6 +128,7 @@ async fn test_device_no_code() {
 #[tokio::test]
 async fn test_device_no_token() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     server.expect(
         Expectation::matching(all_of![
@@ -175,7 +178,12 @@ async fn create_installed_flow_auth(
         "client_secret": "iuMPN6Ne1PD7cos29Tk9rlqH",
         "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob","http://localhost"],
     });
-    struct FD(hyper_util::client::legacy::Client<<DefaultHyperClient as HyperClientBuilder>::Connector>);
+    struct FD(
+        hyper_util::client::legacy::Client<
+            <DefaultHyperClient as HyperClientBuilder>::Connector,
+            String,
+        >,
+    );
     impl InstalledFlowDelegate for FD {
         /// Depending on need_code, return the pre-set code or send the code to the server at
         /// the redirect_uri given in the url.
@@ -234,6 +242,7 @@ async fn create_installed_flow_auth(
 #[tokio::test]
 async fn test_installed_interactive_success() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth =
         create_installed_flow_auth(&server, InstalledFlowReturnMethod::Interactive, None).await;
@@ -266,6 +275,7 @@ async fn test_installed_interactive_success() {
 #[tokio::test]
 async fn test_installed_redirect_success() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth =
         create_installed_flow_auth(&server, InstalledFlowReturnMethod::HTTPRedirect, None).await;
@@ -298,6 +308,7 @@ async fn test_installed_redirect_success() {
 #[tokio::test]
 async fn test_installed_error() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth =
         create_installed_flow_auth(&server, InstalledFlowReturnMethod::Interactive, None).await;
@@ -346,6 +357,7 @@ async fn create_service_account_auth(server: &Server) -> DefaultAuthenticator {
 async fn test_service_account_success() {
     use time::OffsetDateTime;
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth = create_service_account_auth(&server).await;
 
@@ -373,6 +385,7 @@ async fn test_service_account_success() {
 #[tokio::test]
 async fn test_service_account_error() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth = create_service_account_auth(&server).await;
     server.expect(
@@ -392,6 +405,7 @@ async fn test_service_account_error() {
 #[tokio::test]
 async fn test_refresh() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth =
         create_installed_flow_auth(&server, InstalledFlowReturnMethod::Interactive, None).await;
@@ -507,6 +521,7 @@ async fn test_refresh() {
 #[tokio::test]
 async fn test_memory_storage() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let auth =
         create_installed_flow_auth(&server, InstalledFlowReturnMethod::Interactive, None).await;
@@ -574,6 +589,7 @@ async fn test_memory_storage() {
 #[tokio::test]
 async fn test_disk_storage() {
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     let tempdir = tempfile::tempdir().unwrap();
     let storage_path = tempdir.path().join("tokenstorage.json");
@@ -646,6 +662,7 @@ async fn test_disk_storage() {
 async fn test_default_application_credentials_from_metadata_server() {
     use yup_oauth2::authenticator::ApplicationDefaultCredentialsTypes;
     let _ = env_logger::try_init();
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let server = Server::run();
     server.expect(
         Expectation::matching(all_of![

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -175,7 +175,7 @@ async fn create_installed_flow_auth(
         "client_secret": "iuMPN6Ne1PD7cos29Tk9rlqH",
         "redirect_uris": ["urn:ietf:wg:oauth:2.0:oob","http://localhost"],
     });
-    struct FD(hyper::Client<<DefaultHyperClient as HyperClientBuilder>::Connector>);
+    struct FD(hyper_util::client::legacy::Client<<DefaultHyperClient as HyperClientBuilder>::Connector>);
     impl InstalledFlowDelegate for FD {
         /// Depending on need_code, return the pre-set code or send the code to the server at
         /// the redirect_uri given in the url.


### PR DESCRIPTION
Continuation of #216

~currently gracefully http server shutdown is not implemented and depends on https://github.com/hyperium/hyper-util/pull/127~
 http server graceful shutdown got released and is also implemented