### PR TITLE
Enable required features in hyper-rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ http = "1"
 http-body-util = "0.1"
 hyper = "1"
 hyper-util = { version = "0.1.5", features = ["client-legacy", "server-auto", "http1", "http2", "server-graceful"] }
-hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http2"] }
+hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http1", "http2", "rustls-native-certs", "ring"] }
 hyper-tls = { version = "0.6.0", optional = true }
 itertools = "0.13"
 log = "0.4"


### PR DESCRIPTION
Fixes #224 
Currently, the crate does not compile because of missing dependencies, probably because `default-features = false` was set instead of `true`.

This PR enables the required features so that it compiles again. The ring feature was chosen in favor of `aws-lc-rs` because it is already enabled in the `rustls` dependency.