### PR TITLE
Drop itertools dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ hyper = "1"
 hyper-util = { version = "0.1.5", features = ["client-legacy", "server-auto", "http1", "http2", "server-graceful"] }
 hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http1", "http2", "rustls-native-certs", "ring"] }
 hyper-tls = { version = "0.6.0", optional = true }
-itertools = "0.13"
 log = "0.4"
 percent-encoding = "2"
 rustls = { version = "^0.23", optional = true, features = ["ring"] }


### PR DESCRIPTION
This drops the `itertools` dependency in favor of a more efficient implementation based on APIs available through the standard library.