### PR TITLE
Remove dependency on aws-lc-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ http = "1"
 http-body-util = "0.1"
 hyper = "1"
 hyper-util = { version = "0.1.5", features = ["client-legacy", "server-auto", "http1", "http2", "server-graceful"] }
-hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http1", "http2", "rustls-native-certs", "ring"] }
+hyper-rustls = { version = "0.27", optional = true, default-features = false, features = ["http1", "http2", "rustls-native-certs", "ring", "native-tokio"] }
 hyper-tls = { version = "0.6.0", optional = true }
 log = "0.4"
 percent-encoding = "2"
-rustls = { version = "^0.23", optional = true }
+rustls = { version = "^0.23", optional = true, default-features = false, features = ["ring", "std"] }
 rustls-pemfile = { version = "2.0.0", optional = true }
 seahash = "4"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Since the default provider of `rustls` is `aws-lc-rs` and we use `ring` already in `hyper-rustls`, it makes sense to me to switch completely to `ring` and avoid the `aws-lc-rs` dependency.