### PR TITLE
redirect_uri=localhost instead of 127.0.0.1

### DIFF
--- a/src/installed.rs
+++ b/src/installed.rs
@@ -20,6 +20,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::oneshot;
 use tower_service::Service;
 use url::form_urlencoded;
+use url::quirks::port;
 
 const QUERY_SET: AsciiSet = CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
 
@@ -204,7 +205,7 @@ impl InstalledFlow {
         // by certain providers.
         let redirect_uri: Cow<str> = match self.flow_delegate.redirect_uri() {
             Some(uri) => uri.into(),
-            None => format!("http://{}", server_addr).into(),
+            None => format!("http://localhost:{}", server_addr.port()).into(),
         };
         let url = build_authentication_request_url(
             &app_secret.auth_uri,
@@ -255,7 +256,7 @@ impl InstalledFlow {
         use std::borrow::Cow;
         let redirect_uri: Cow<str> = match (custom_redirect_uri, server_addr) {
             (Some(uri), _) => uri.into(),
-            (None, Some(addr)) => format!("http://{}", addr).into(),
+            (None, Some(addr)) => format!("http://localhost:{}", addr.port()).into(),
             (None, None) => OOB_REDIRECT_URI.into(),
         };
 


### PR DESCRIPTION
Facebook GraphAPI doesn't support 127.0.0.1 as redirect_uri