### PR TITLE
do not set rustls default provider

### DIFF
--- a/src/service_account.rs
+++ b/src/service_account.rs
@@ -243,7 +243,7 @@ mod tests {
             hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                 .build(
                     hyper_rustls::HttpsConnectorBuilder::new()
-                        .with_native_roots()
+                        .with_provider_and_native_roots(rustls::crypto::ring::default_provider())
                         .unwrap()
                         .https_only()
                         .enable_http1()


### PR DESCRIPTION
only applications should be setting default from main: https://docs.rs/rustls/latest/rustls/crypto/struct.CryptoProvider.html#using-the-per-process-default-cryptoprovider