### PR TITLE
Use thiserror instead of anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ hyper-tls = ["dep:hyper-tls", "__rustls"]
 __rustls = ["dep:rustls"]
 
 [dependencies]
-anyhow = "1.0.38"
 async-trait = "^0.1"
 base64 = "0.22"
 futures = "0.3"
@@ -55,6 +54,7 @@ rustls-pemfile = { version = "2.0.0", optional = true }
 seahash = "4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "1.0.61"
 time = { version = "0.3.7", features = ["local-offset", "parsing", "serde"] }
 tokio = { version = "1.0", features = [ "fs", "macros", "io-std", "io-util", "time", "sync", "rt"] }
 url = "2"

--- a/examples/custom_storage.rs
+++ b/examples/custom_storage.rs
@@ -1,8 +1,7 @@
 //! Demonstrating how to create a custom token store
-use anyhow::anyhow;
 use async_trait::async_trait;
-use std::sync::RwLock;
-use yup_oauth2::storage::{TokenInfo, TokenStorage};
+use std::{borrow::Cow, sync::RwLock};
+use yup_oauth2::storage::{TokenInfo, TokenStorage, TokenStorageError};
 
 struct ExampleTokenStore {
     store: RwLock<Vec<StoredToken>>,
@@ -25,15 +24,16 @@ fn scopes_covered_by(scopes: &[&str], possible_match_or_superset: &[&str]) -> bo
 /// to disk, an OS keychain, a database or whatever suits your use-case
 #[async_trait]
 impl TokenStorage for ExampleTokenStore {
-    async fn set(&self, scopes: &[&str], token: TokenInfo) -> anyhow::Result<()> {
-        let data = serde_json::to_string(&token).unwrap();
+    async fn set(&self, scopes: &[&str], token: TokenInfo) -> Result<(), TokenStorageError> {
+        let data = serde_json::to_string(&token).map_err(|e| {
+            TokenStorageError::Other(Cow::Owned(format!("Failed to parse JSON: {e}")))
+        })?;
 
         println!("Storing token for scopes {:?}", scopes);
 
-        let mut store = self
-            .store
-            .write()
-            .map_err(|_| anyhow!("Unable to lock store for writing"))?;
+        let mut store = self.store.write().map_err(|_| {
+            TokenStorageError::Other(Cow::Borrowed("Unable to lock store for writing"))
+        })?;
 
         store.push(StoredToken {
             scopes: scopes.iter().map(|str| str.to_string()).collect(),


### PR DESCRIPTION
In libraries, it is [recommended](https://google.github.io/comprehensive-rust/error-handling/thiserror-and-anyhow.html) to use `thiserror` instead of `anyhow`.
I would like to add a timeout to the hyper client in a future PR, which is easier when working with `thiserror`.