### PR TITLE
Drop dependency on futures crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ __rustls = ["dep:rustls"]
 [dependencies]
 async-trait = "^0.1"
 base64 = "0.22"
-futures = "0.3"
 http = "1"
 http-body-util = "0.1"
 hyper = "1"

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -22,7 +22,6 @@ use private::AuthFlow;
 
 use crate::access_token::AccessTokenFlow;
 
-use futures::lock::Mutex;
 use hyper_util::client::legacy::connect::Connect;
 use std::borrow::Cow;
 use std::fmt;
@@ -30,6 +29,7 @@ use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
 
 struct InnerAuthenticator<C>
 where

--- a/src/installed.rs
+++ b/src/installed.rs
@@ -7,7 +7,6 @@ use crate::client::SendRequest;
 use crate::error::Error;
 use crate::types::{ApplicationSecret, TokenInfo};
 
-use futures::lock::Mutex;
 use http_body_util::BodyExt;
 use std::convert::AsRef;
 use std::net::SocketAddr;
@@ -15,7 +14,7 @@ use std::sync::Arc;
 
 use http::header;
 use percent_encoding::{percent_encode, AsciiSet, CONTROLS};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Mutex};
 use url::form_urlencoded;
 
 const QUERY_SET: AsciiSet = CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
@@ -349,10 +348,9 @@ impl InstalledFlowServer {
 }
 
 mod installed_flow_server {
-    use futures::lock::Mutex;
     use http::{Request, Response, StatusCode, Uri};
     use std::sync::Arc;
-    use tokio::sync::oneshot;
+    use tokio::sync::{oneshot, Mutex};
     use url::form_urlencoded;
 
     pub(super) async fn handle_req<B: hyper::body::Body>(

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -4,11 +4,11 @@
 //
 pub use crate::types::TokenInfo;
 
-use futures::lock::Mutex;
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 use async_trait::async_trait;
 


### PR DESCRIPTION
This drops the `futures` crate by replacing all uses of `Mutex` with `tokio`s mutexes. `futures` is a big dependency and we should be able to do everything with what `tokio` gives us. Using tokio API also makes tools like `tokio-console` work for this crate too.