### PR TITLE
fix: Remove unmaintained `rustls-pemfile` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ required-features = ["hyper-rustls", "service-account"]
 [features]
 default = ["hyper-rustls", "service-account", "ring"]
 service_account = ["service-account"]
-service-account = ["rustls-pemfile"]
+service-account = []
 hyper-rustls = ["dep:hyper-rustls", "__rustls"]
 ring = ["rustls/ring", "hyper-rustls?/ring"]
 aws-lc-rs = ["rustls/aws_lc_rs", "hyper-rustls?/aws-lc-rs"]
@@ -49,7 +49,6 @@ hyper-tls = { version = "0.6.0", optional = true }
 log = "0.4"
 percent-encoding = "2"
 rustls = { version = "^0.23", optional = true, default-features = false, features = ["std"] }
-rustls-pemfile = { version = "2.0.0", optional = true }
 seahash = "4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
According to [RUSTSEC-2025-0134] dependency `rustls-pemfile` is unmaintained. Its functionality has been incorporated into `rustls-pki-types`. This commit removes this `rustls-pemfile` dependency.

This fixes issue #251.